### PR TITLE
Update github-pr-workflow.md

### DIFF
--- a/.claude/github-pr-workflow.md
+++ b/.claude/github-pr-workflow.md
@@ -93,8 +93,8 @@ gh api repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/requested_reviewers \
 ### 2.2 レビュー結果確認
 
 ```bash
-# 2分待機
-sleep 120
+# 1分待機
+sleep 60
 
 # 新しいレビュー確認
 TIMESTAMP=$(date -u -d '5 minutes ago' +"%Y-%m-%dT%H:%M:%SZ")
@@ -104,6 +104,8 @@ gh api repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/reviews \
 # 個別コメント確認
 gh api repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/comments \
   --jq ".[] | select(.created_at > \"$TIMESTAMP\") | {body: .body, line: .line, path: .path}"
+
+# まだレビュー結果が出ていなかったら、再度1分待機する。最低5回は確認を繰り返す
 ```
 
 ### 2.3 コメント分析と対応
@@ -239,6 +241,9 @@ mutation {
 gh api repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/requested_reviewers \
   -X POST --field "reviewers[]=copilot-pull-request-reviewer[bot]"
 ```
+
+再レビュー依頼後、またレビュー内容が上がってくるまで待機する。「2.2 レビュー結果確認」に戻る。  
+対応必要なものがなくなった場合は、完了とする。完了条件チェックリストで確認すること。
 
 ## 🔧 3. CI/CD 対応
 


### PR DESCRIPTION
This pull request updates the `.claude/github-pr-workflow.md` file to improve the GitHub PR review workflow by reducing wait times and adding clarity to the review and re-review process.

### Improvements to review workflow:

* Reduced the initial wait time for review results from 2 minutes to 1 minute by modifying the `sleep` command. (`.claude/github-pr-workflow.md`, [.claude/github-pr-workflow.mdL96-R97](diffhunk://#diff-c4f6b5d9a721e3442c8ba1b73cc68c58e52d963d1d4c78cd3c62a5e39d20e121L96-R97))
* Added a note to repeat the review result check up to 5 times, with a 1-minute wait between each check, if no results are available yet. (`.claude/github-pr-workflow.md`, [.claude/github-pr-workflow.mdR107-R108](diffhunk://#diff-c4f6b5d9a721e3442c8ba1b73cc68c58e52d963d1d4c78cd3c62a5e39d20e121R107-R108))

### Enhancements to re-review process:

* Added instructions to return to the "2.2 レビュー結果確認" section after re-requesting a review and clarified the completion criteria using a checklist. (`.claude/github-pr-workflow.md`, [.claude/github-pr-workflow.mdR245-R247](diffhunk://#diff-c4f6b5d9a721e3442c8ba1b73cc68c58e52d963d1d4c78cd3c62a5e39d20e121R245-R247))