### PR TITLE
📚 Add comprehensive JSDoc documentation

### DIFF
--- a/.claude/development-patterns.md
+++ b/.claude/development-patterns.md
@@ -1,5 +1,177 @@
 # 開発パターンガイド
 
+## JSDoc ドキュメンテーション標準
+
+### ドキュメント品質レベル
+
+#### ✅ 優秀な JSDoc 実装例
+- **CrawlerService**: 包括的なJSDocと詳細な使用例
+- **TweetService**: 完全なAPI ドキュメントと使用パターン
+- **QueueService**: 完全なパラメータと戻り値のドキュメント
+- **Storage**: 型安全なドキュメントとエラーハンドリング
+- **DomUtils**: 詳細な使用例とエッジケース
+- **ScrollUtils**: 包括的な動作説明
+
+#### 🟢 最近改善済み（Issue #24 対応）
+- **ConfigManager**: 包括的なJSDocを新規追加
+- **NotificationService**: 完全なAPI ドキュメントを追加
+- **VersionService**: エラーハンドリング例を含む強化ドキュメント
+
+### JSDoc 要件
+
+#### 必須要素
+すべてのパブリックメソッドに含める必要がある要素：
+
+```typescript
+/**
+ * メソッドが何をするかの簡潔な説明
+ * 
+ * メソッドの目的、動作、重要な注意点の詳細説明。
+ * 副作用、依存関係、使用コンテキストの情報を含める。
+ * 
+ * @param {Type} paramName - パラメータの説明
+ * @param {Type} [optionalParam=defaultValue] - オプションパラメータの説明
+ * @returns {ReturnType} 戻り値の説明
+ * 
+ * @throws {ErrorType} このエラーがスローされる条件の説明
+ * 
+ * @example
+ * ```typescript
+ * // 実用的な使用例
+ * const result = SomeService.methodName('parameter')
+ * if (result) {
+ *   // 成功ケースの処理
+ * }
+ * ```
+ */
+```
+
+#### パラメータ ドキュメント
+- **型注釈**: 明確性のために `{Type}` 形式を使用
+- **オプションパラメータ**: `[paramName]` または `[paramName=default]` でマーク
+- **複合型**: インターフェースとユニオン型を明示的に参照
+- **コールバック関数**: コールバックシグネチャと目的をドキュメント
+
+#### 戻り値ドキュメント
+- **常に戻り値型をドキュメント**: `void` メソッドでも副作用を説明
+- **Promise 処理**: Promise が何に解決されるかを指定
+- **条件付き戻り値**: 異なる戻り値シナリオをドキュメント
+
+#### エラー ドキュメント
+- **すべてのスローされるエラーをリスト**: カスタムと組み込みエラー型を含む
+- **エラー条件**: 各エラーが発生する条件を説明
+- **エラーハンドリング例**: 適切な try-catch 使用方法を表示
+
+#### 使用例
+- **実用的なシナリオ**: 実世界の使用パターンを表示
+- **エッジケース**: 重要な制限や特別な動作をドキュメント
+- **統合例**: メソッドがどのように連携するかを表示
+
+### クラスレベル ドキュメント
+
+サービスクラスとユーティリティの場合：
+
+```typescript
+/**
+ * クラスの目的の簡潔な説明
+ * 
+ * アプリケーションにおけるクラスの役割、依存関係、
+ * 全体アーキテクチャでの位置づけの詳細説明。
+ * 
+ * @example
+ * ```typescript
+ * // 一般的な使用パターン
+ * ServiceClass.mainMethod()
+ * ```
+ */
+export const ServiceClass = {
+  // メソッド...
+}
+```
+
+### 更新されたドキュメント例（Issue #24 修正）
+
+#### ConfigManager ドキュメントパターン
+```typescript
+/**
+ * アプリケーション設定の管理を行うクラス
+ * 
+ * Tampermonkey の GM_config を使用してユーザー設定の読み書きを行い、
+ * メニューコマンドの登録とユーザーインターフェースを提供する。
+ */
+export const ConfigManager = {
+  /**
+   * Tampermonkey にユーザー設定メニューを登録する
+   * 
+   * GM_config を使用して「設定」メニューを追加し、
+   * ユーザーがブラウザ上で設定を変更できるUIを提供する。
+   * 
+   * @throws {Error} GM_config が利用できない場合
+   * @example
+   * ```typescript
+   * ConfigManager.registerMenuCommand()
+   * ```
+   */
+  registerMenuCommand(): void
+}
+```
+
+#### NotificationService ドキュメントパターン
+```typescript
+/**
+ * 外部サービスへの通知機能を提供するクラス
+ * 
+ * Discord Webhook を使用したメッセージ送信機能を提供し、
+ * スパムツイート検出時やシステム更新時の通知に使用される。
+ */
+export const NotificationService = {
+  /**
+   * Discord Webhook を使用してメッセージを送信する
+   * 
+   * @param {string} message - 送信するメッセージ内容
+   * @param {(_response: Response) => void} [callback] - レスポンス受信時のコールバック関数
+   * @param {boolean} [withReply=false] - true の場合、メッセージにメンションを付加
+   * @returns {Promise<void>} 送信完了を表すPromise
+   * 
+   * @throws {Error} ネットワークエラーまたはDiscord API エラー
+   * 
+   * @example
+   * ```typescript
+   * // 基本的な通知
+   * await NotificationService.notifyDiscord('新しいスパムツイートを検出しました')
+   * 
+   * // メンション付き通知
+   * await NotificationService.notifyDiscord('緊急：大量のスパムを検出', undefined, true)
+   * ```
+   */
+  notifyDiscord(message: string, callback?: (_response: Response) => void, withReply = false): Promise<void>
+}
+```
+
+### ドキュメント保守
+
+#### ドキュメント更新が必要な場合
+1. **新しいメソッド追加**: 常に包括的なJSDocを含める
+2. **API 変更**: パラメータ型と説明を更新
+3. **動作変更**: メソッド説明と例を修正
+4. **エラーハンドリング変更**: `@throws` ドキュメントを更新
+5. **新しい使用パターン**: 関連する例を追加
+
+#### 品質チェックリスト
+- [ ] 明確で簡潔な説明
+- [ ] すべてのパラメータが型付きでドキュメント化
+- [ ] 戻り値が明確に説明
+- [ ] エラー条件がドキュメント化
+- [ ] 実用的な使用例が含まれる
+- [ ] 日本語コメントが適切（プロジェクトスタイルに一致）
+- [ ] 既存ドキュメントと一貫した書式
+
+#### レビュープロセス
+1. **セルフレビュー**: 品質チェックリストで確認
+2. **例の検証**: コード例が機能することを確認
+3. **型の一貫性**: 型が実装と一致することを確認
+4. **言語の一貫性**: プロジェクト慣例に従った日本語/英語バランスを維持
+
 ## ユーザースクリプト API使用
 
 ### ストレージ操作

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,66 @@ git checkout -b feature/new-feature origin/master
 4. **rebase continue**: `git rebase --continue`
 5. **force push**: `git push --force-with-lease origin HEAD`
 
+## Pull Request 作成ガイドライン
+
+### Issue 自動クローズ機能
+
+Pull Request 作成時、元の GitHub Issue が PR マージと同時に自動クローズされるように、本文に適切なキーワードを含める：
+
+#### 自動クローズキーワード
+以下のキーワードのいずれかを PR 本文に含める：
+- `closes #<issue番号>`
+- `fixes #<issue番号>`
+- `resolves #<issue番号>`
+
+#### PR 本文テンプレート
+```markdown
+## Summary
+- [実装内容の1-3行での要約]
+
+## Changes
+- [主要な変更点のリスト]
+- [新機能・修正・改善の詳細]
+
+## Test Plan
+- [x] テスト実行: `pnpm test`
+- [x] リンティング: `pnpm run lint`
+- [x] [その他の検証項目]
+
+Closes #<issue番号>
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+```
+
+#### 使用例（Issue #24対応）
+```markdown
+## Summary
+- JSDoc ドキュメントが不足していた ConfigManager、NotificationService、VersionService に包括的な JSDoc を追加
+- 開発パターンガイドにJSDoc標準を追加してドキュメント品質の一貫性を確保
+
+## Changes
+- ConfigManager: 全メソッドに詳細なJSDoc追加（パラメータ、戻り値、使用例を含む）
+- NotificationService: notifyDiscord メソッドに包括的なJSDoc追加
+- VersionService: notifyVersionUpdate メソッドのJSDoc強化
+- `.claude/development-patterns.md`: JSDoc標準とベストプラクティスを追加
+
+## Test Plan
+- [x] テスト実行: `pnpm test` - 全テスト通過
+- [x] リンティング: `pnpm run lint` - コード品質チェック通過
+- [x] JSDoc構文確認: TypeScriptコンパイル成功
+
+Closes #24
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+```
+
+### 重要な注意点
+
+1. **Issue番号の正確性**: 対応する Issue 番号を正確に記載
+2. **キーワードの配置**: `Closes #24` は本文の任意の場所に配置可能
+3. **複数Issue対応**: `Closes #24, closes #25` のように複数指定可能
+4. **大文字小文字**: `closes`, `Closes`, `CLOSES` いずれも有効
+
 ## 重要：ファイル変更時の必須事項
 
 **ファイルを変更した場合は必ずコミットすること！**

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,6 +1,36 @@
 // Types from userscript.d.ts are globally available
 
+/**
+ * アプリケーション設定の管理を行うクラス
+ *
+ * Tampermonkey の GM_config を使用してユーザー設定の読み書きを行い、
+ * メニューコマンドの登録とユーザーインターフェースを提供する。
+ *
+ * @example
+ * ```typescript
+ * // 設定メニューの登録
+ * ConfigManager.registerMenuCommand()
+ *
+ * // Discord Webhook URL の取得
+ * const webhookUrl = ConfigManager.getDiscordWebhookUrl()
+ * ```
+ */
 export const ConfigManager = {
+  /**
+   * Tampermonkey にユーザー設定メニューを登録する
+   *
+   * GM_config を使用して「設定」メニューを追加し、
+   * ユーザーがブラウザ上で設定を変更できるUIを提供する。
+   * Discord Webhook URL、コメント、ホーム限定モードの設定項目を含む。
+   *
+   * @throws {Error} GM_config が利用できない場合
+   *
+   * @example
+   * ```typescript
+   * // ページ読み込み時に設定メニューを登録
+   * ConfigManager.registerMenuCommand()
+   * ```
+   */
   registerMenuCommand(): void {
     GM_config(
       {
@@ -28,14 +58,62 @@ export const ConfigManager = {
     })
   },
 
+  /**
+   * Discord Webhook URL を取得する
+   *
+   * ユーザーが設定したDiscord Webhook URLを GM_getValue から取得する。
+   * 未設定の場合は空文字列を返す。
+   *
+   * @returns {string} ユーザーが設定したDiscord Webhook URL。
+   *                   未設定の場合は空文字列を返す。
+   *
+   * @example
+   * ```typescript
+   * const webhookUrl = ConfigManager.getDiscordWebhookUrl()
+   * if (webhookUrl) {
+   *   await NotificationService.notifyDiscord('メッセージ')
+   * }
+   * ```
+   */
   getDiscordWebhookUrl(): string {
     return GM_getValue('discordWebhookUrl', '')
   },
 
+  /**
+   * ツイート保存時のコメント設定を取得する
+   *
+   * ユーザーが設定したコメント文字列を GM_getValue から取得する。
+   * このコメントはDiscord通知時にメッセージと一緒に送信される。
+   *
+   * @returns {string} ユーザーが設定したコメント文字列。
+   *                   未設定の場合は空文字列を返す。
+   *
+   * @example
+   * ```typescript
+   * const comment = ConfigManager.getComment()
+   * const tweetData = { ...tweet, comment }
+   * ```
+   */
   getComment(): string {
     return GM_getValue('comment', '')
   },
 
+  /**
+   * ホームページ限定モードの設定を取得する
+   *
+   * ユーザーが設定したホーム限定モードのオン/オフ状態を GM_getValue から取得する。
+   * true の場合、クロール処理はホームページでのみ実行される。
+   *
+   * @returns {boolean} true の場合、ホームページでのみクロール実行
+   *                    false の場合、全ページでクロール実行
+   *
+   * @example
+   * ```typescript
+   * if (ConfigManager.getIsOnlyHome() && !isHomePage()) {
+   *   return // ホーム限定モードでホーム以外なので終了
+   * }
+   * ```
+   */
   getIsOnlyHome(): boolean {
     const value = GM_getValue('isOnlyHome', 'false')
     // @ts-expect-error string型で比較が行われるため

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -1,7 +1,41 @@
 import { DISCORD_MENTION_ID } from '@/core/constants'
 import { ConfigManager } from '@/core/config'
 
+/**
+ * 外部サービスへの通知機能を提供するクラス
+ *
+ * Discord Webhook を使用したメッセージ送信機能を提供し、
+ * スパムツイート検出時やシステム更新時の通知に使用される。
+ */
 export const NotificationService = {
+  /**
+   * Discord Webhook を使用してメッセージを送信する
+   *
+   * 指定されたメッセージをDiscord Webhookを通じて送信する。
+   * メンション付きオプション、ユーザー設定コメントの自動追加、
+   * エラーハンドリングを含む包括的な通知機能を提供する。
+   *
+   * @param {string} message - 送信するメッセージ内容
+   * @param {(_response: Response) => void} [callback] - レスポンス受信時のコールバック関数
+   * @param {boolean} [withReply=false] - true の場合、メッセージにメンションを付加
+   * @returns {Promise<void>} 送信完了を表すPromise
+   *
+   * @throws {Error} ネットワークエラーまたはDiscord API エラー
+   *
+   * @example
+   * ```typescript
+   * // 基本的な通知
+   * await NotificationService.notifyDiscord('新しいスパムツイートを検出しました')
+   *
+   * // メンション付き通知
+   * await NotificationService.notifyDiscord('緊急：大量のスパムを検出', undefined, true)
+   *
+   * // コールバック付き通知
+   * NotificationService.notifyDiscord('メッセージ', (response) => {
+   *   console.log('送信ステータス:', response.status)
+   * })
+   * ```
+   */
   notifyDiscord(
     message: string,
     callback?: (_response: Response) => void,

--- a/src/services/version-service.ts
+++ b/src/services/version-service.ts
@@ -39,8 +39,22 @@ export const VersionService = {
 
   /**
    * バージョン更新をDiscordに通知する（example.com経由）
-   * @param oldVersion 以前のバージョン
-   * @param newVersion 新しいバージョン
+   *
+   * バージョン更新時に新しいウィンドウを開いてexample.comに通知情報を送信する。
+   * ポップアップブロッカーにより失敗する可能性があるため、エラーハンドリングを含む。
+   *
+   * @param {string} oldVersion - 以前のバージョン
+   * @param {string} newVersion - 新しいバージョン
+   * @throws {Error} ポップアップブロックまたはウィンドウオープンに失敗した場合
+   *
+   * @example
+   * ```typescript
+   * try {
+   *   VersionService.notifyVersionUpdate('1.0.0', '1.1.0')
+   * } catch (error) {
+   *   console.error('バージョン更新通知に失敗:', error)
+   * }
+   * ```
    */
   notifyVersionUpdate(oldVersion: string, newVersion: string): void {
     const notifyUrl = `https://example.com/?update-notify&old=${encodeURIComponent(oldVersion)}&new=${encodeURIComponent(newVersion)}`


### PR DESCRIPTION
## Summary
- JSDoc ドキュメントが不足していた ConfigManager、NotificationService、VersionService に包括的な JSDoc を追加
- 開発パターンガイドにJSDoc標準を追加してドキュメント品質の一貫性を確保

## Changes
- **ConfigManager**: 全メソッドに詳細なJSDoc追加（パラメータ、戻り値、使用例を含む）
- **NotificationService**: notifyDiscord メソッドに包括的なJSDoc追加
- **VersionService**: notifyVersionUpdate メソッドのJSDoc強化
- **`.claude/development-patterns.md`**: JSDoc標準とベストプラクティスを追加
- **`CLAUDE.md`**: PR本文テンプレートと自動Issue クローズ機能を追加

## Test Plan
- [x] テスト実行: `pnpm test` - 全テスト通過
- [x] リンティング: `pnpm run lint` - コード品質チェック通過
- [x] JSDoc構文確認: TypeScriptコンパイル成功

## Documentation Quality Improvements
- 型安全なパラメータドキュメント
- 実用的な使用例とエラーハンドリング
- 一貫したドキュメントスタイル
- 日本語コメントとのバランス

Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)