### PR TITLE
fix: TypeScript v6.0 の ignoreDeprecations を廃止し tsconfig を根本修正する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,13 +23,11 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "types": ["node", "jest"],
     "newLine": "LF",
     "resolveJsonModule": true,
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## Summary

TypeScript v6.0 アップグレード時の暫定対応として追加された `ignoreDeprecations: "6.0"` を削除し、根本的な修正を行います。

## Changes

- `baseUrl: "."` を削除
- `paths` の `@/*` を `["src/*"]` から `["./src/*"]` に変更（tsconfig.json 起点の相対パスに修正）
- `ignoreDeprecations: "6.0"` を削除（TypeScript 7.0 では無効化されるため、早急な対応が必要）

## 変更の理由

1. **`baseUrl` 削除 + `paths` を相対パスに更新** — `baseUrl: "."` を削除した場合、`paths` は tsconfig.json 起点の相対パス `"./src/*"` に変更する必要があります
2. **`ignoreDeprecations: "6.0"` 削除** — TypeScript 7.0 では機能しなくなるため、根本的な修正が必要でした

## Test Plan

- [x] ビルド確認: `pnpm run build` — 正常にコンパイル完了
- [x] 型チェック: `tsc --noEmit` — エラーなし
- [x] リンティング: `pnpm run lint` — エラーなし

Fixes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)