### PR TITLE
fix: eslint-plugin-unicorn v65 対応 (no-this-outside-of-class 他、大規模)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@book000/eslint-config": "1.14.55",
+    "@book000/eslint-config": "1.14.61",
     "@types/greasemonkey": "4.0.7",
     "@types/jest": "30.0.0",
     "@types/jsdom": "28.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@book000/eslint-config':
-        specifier: 1.14.55
-        version: 1.14.55(eslint@10.4.1)(typescript@6.0.3)
+        specifier: 1.14.61
+        version: 1.14.61(eslint@10.4.1)(typescript@6.0.3)
       '@types/greasemonkey':
         specifier: 4.0.7
         version: 4.0.7
@@ -257,8 +257,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@book000/eslint-config@1.14.55':
-    resolution: {integrity: sha512-eIfvJO7jdJYiWVmbQQuBmAsNeyeo7wcmX+R8selUJCE6d1cf2mCy2GE+x/R/l1MdPxrzxu6cjR+0qyiuVqBTgg==}
+  '@book000/eslint-config@1.14.61':
+    resolution: {integrity: sha512-k3lYxTYQdjTz/EkCfcAy/FxR7aUwg/z6QZm/n6q2FbrnVHCNGksBHoRhVou50VahfWkqW7C+z35Me6krEEK4yA==}
     peerDependencies:
       eslint: 10.4.1
 
@@ -634,6 +634,14 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/eslint-plugin@8.61.0':
+    resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.61.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.60.1':
     resolution: {integrity: sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -687,6 +695,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/type-utils@8.61.0':
+    resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.60.1':
     resolution: {integrity: sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -709,6 +724,13 @@ packages:
 
   '@typescript-eslint/utils@8.60.1':
     resolution: {integrity: sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.61.0':
+    resolution: {integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1136,10 +1158,6 @@ packages:
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
-  clean-regexp@1.0.0:
-    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
-    engines: {node: '>=4'}
-
   cli-spinners@3.4.0:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
@@ -1261,6 +1279,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  detect-indent@7.0.2:
+    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
+    engines: {node: '>=12.20'}
+
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -1355,10 +1377,6 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
-  escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
-
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
@@ -1450,8 +1468,8 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-unicorn@64.0.0:
-    resolution: {integrity: sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA==}
+  eslint-plugin-unicorn@65.0.1:
+    resolution: {integrity: sha512-daCrQrgxOoOz2uMPWB3Y3vvv/5q+ncwICI8IjoebiwtW87CaY4tAN5EEiRXTYVnf7qi1v1BGBdHOSnZLV0rx6A==}
     engines: {node: ^20.10.0 || >=21.0.0}
     peerDependencies:
       eslint: '>=9.38.0'
@@ -2504,10 +2522,6 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
-  regexp-tree@0.1.27:
-    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
-    hasBin: true
-
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -2955,6 +2969,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript-eslint@8.61.0:
+    resolution: {integrity: sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -3382,15 +3403,15 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@book000/eslint-config@1.14.55(eslint@10.4.1)(typescript@6.0.3)':
+  '@book000/eslint-config@1.14.61(eslint@10.4.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1)(typescript@6.0.3)
       eslint: 10.4.1
       eslint-config-prettier: 10.1.8(eslint@10.4.1)
-      eslint-plugin-unicorn: 64.0.0(eslint@10.4.1)
+      eslint-plugin-unicorn: 65.0.1(eslint@10.4.1)
       globals: 17.6.0
       neostandard: 0.13.0(eslint@10.4.1)(typescript@6.0.3)
-      typescript-eslint: 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      typescript-eslint: 8.61.0(eslint@10.4.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3877,6 +3898,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/type-utils': 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      eslint: 10.4.1
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.1
@@ -3903,8 +3940,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.60.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -3942,6 +3979,18 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
       '@typescript-eslint/utils': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.4.1
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.61.0(eslint@10.4.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 10.4.1
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -3989,6 +4038,17 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      eslint: 10.4.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.0(eslint@10.4.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
       eslint: 10.4.1
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4434,10 +4494,6 @@ snapshots:
 
   cjs-module-lexer@2.2.0: {}
 
-  clean-regexp@1.0.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-
   cli-spinners@3.4.0: {}
 
   cli-truncate@4.0.0:
@@ -4552,6 +4608,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  detect-indent@7.0.2: {}
 
   detect-newline@3.1.0: {}
 
@@ -4699,8 +4757,6 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-string-regexp@1.0.5: {}
-
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -4825,14 +4881,14 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-unicorn@64.0.0(eslint@10.4.1):
+  eslint-plugin-unicorn@65.0.1(eslint@10.4.1):
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1)
       change-case: 5.4.4
       ci-info: 4.4.0
-      clean-regexp: 1.0.0
       core-js-compat: 3.49.0
+      detect-indent: 7.0.2
       eslint: 10.4.1
       find-up-simple: 1.0.1
       globals: 17.6.0
@@ -4840,7 +4896,6 @@ snapshots:
       is-builtin-module: 5.0.0
       jsesc: 3.1.0
       pluralize: 8.0.0
-      regexp-tree: 0.1.27
       regjsparser: 0.13.1
       semver: 7.8.2
       strip-indent: 4.1.1
@@ -6154,8 +6209,6 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
-  regexp-tree@0.1.27: {}
-
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.9
@@ -6619,6 +6672,17 @@ snapshots:
       '@typescript-eslint/parser': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
       '@typescript-eslint/utils': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      eslint: 10.4.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.61.0(eslint@10.4.1)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1)(typescript@6.0.3)
       eslint: 10.4.1
       typescript: 6.0.3
     transitivePeerDependencies:

--- a/src/__tests__/services/tweet-service.test.ts
+++ b/src/__tests__/services/tweet-service.test.ts
@@ -381,11 +381,12 @@ describe('TweetService', () => {
      * - 閾値チェックの正確な動作確認
      */
     it('should return true when tweets count exceeds limit', () => {
-      const tweets = Array.from({ length: THRESHOLDS.SAVED_TWEETS_LIMIT + 1 })
-        .fill({})
-        .map((_, index) => ({
+      const tweets = Array.from(
+        { length: THRESHOLDS.SAVED_TWEETS_LIMIT + 1 },
+        (_, index) => ({
           tweetId: index.toString(),
-        }))
+        })
+      )
 
       ;(Storage.getSavedTweets as jest.Mock).mockReturnValue(tweets)
 
@@ -400,11 +401,12 @@ describe('TweetService', () => {
      * - ダウンロード不要状態の正確な判定
      */
     it('should return false when tweets count is below limit', () => {
-      const tweets = Array.from({ length: THRESHOLDS.SAVED_TWEETS_LIMIT - 1 })
-        .fill({})
-        .map((_, index) => ({
+      const tweets = Array.from(
+        { length: THRESHOLDS.SAVED_TWEETS_LIMIT - 1 },
+        (_, index) => ({
           tweetId: index.toString(),
-        }))
+        })
+      )
 
       ;(Storage.getSavedTweets as jest.Mock).mockReturnValue(tweets)
 
@@ -419,11 +421,12 @@ describe('TweetService', () => {
      * - 境界値での正確な判定動作確認
      */
     it('should return false when tweets count equals limit', () => {
-      const tweets = Array.from({ length: THRESHOLDS.SAVED_TWEETS_LIMIT })
-        .fill({})
-        .map((_, index) => ({
+      const tweets = Array.from(
+        { length: THRESHOLDS.SAVED_TWEETS_LIMIT },
+        (_, index) => ({
           tweetId: index.toString(),
-        }))
+        })
+      )
 
       ;(Storage.getSavedTweets as jest.Mock).mockReturnValue(tweets)
 

--- a/src/__tests__/utils/dom.test.ts
+++ b/src/__tests__/utils/dom.test.ts
@@ -109,11 +109,13 @@ describe('DomUtils', () => {
       const div = document.createElement('div')
       div.className = 'css-175oi2r'
 
-      const svg = document.createElementNS('https://www.w3.org/2000/svg', 'svg')
+      /* eslint-disable unicorn/prefer-https -- SVG namespace URI は W3C 仕様上 http:// で定義されており変更不可 */
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
       const path = document.createElementNS(
-        'https://www.w3.org/2000/svg',
+        'http://www.w3.org/2000/svg',
         'path'
       )
+      /* eslint-enable unicorn/prefer-https */
       path.setAttribute(
         'd',
         'M12 4c-4.418 0-8 3.58-8 8s3.582 8 8 8c3.806 0 6.993-2.66 7.802-6.22l1.95.44C20.742 18.67 16.76 22 12 22 6.477 22 2 17.52 2 12S6.477 2 12 2c3.272 0 6.176 1.57 8 4V3.5h2v6h-6v-2h2.616C17.175 5.39 14.749 4 12 4z'

--- a/src/__tests__/utils/dom.test.ts
+++ b/src/__tests__/utils/dom.test.ts
@@ -109,9 +109,9 @@ describe('DomUtils', () => {
       const div = document.createElement('div')
       div.className = 'css-175oi2r'
 
-      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      const svg = document.createElementNS('https://www.w3.org/2000/svg', 'svg')
       const path = document.createElementNS(
-        'http://www.w3.org/2000/svg',
+        'https://www.w3.org/2000/svg',
         'path'
       )
       path.setAttribute(

--- a/src/__tests__/utils/page-test-utils.ts
+++ b/src/__tests__/utils/page-test-utils.ts
@@ -43,8 +43,10 @@ export function setupFailedPageDOM(): void {
   const div = document.createElement('div')
   div.className = FAILED_PAGE_CLASS
 
-  const svg = document.createElementNS('https://www.w3.org/2000/svg', 'svg')
-  const path = document.createElementNS('https://www.w3.org/2000/svg', 'path')
+  // eslint-disable-next-line unicorn/prefer-https -- SVG namespace URI は W3C 仕様上 http:// で定義されており変更不可
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  // eslint-disable-next-line unicorn/prefer-https -- SVG namespace URI は W3C 仕様上 http:// で定義されており変更不可
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
   path.setAttribute(
     'd',
     'M12 4c-4.418 0-8 3.58-8 8s3.582 8 8 8c3.806 0 6.993-2.66 7.802-6.22l1.95.44C20.742 18.67 16.76 22 12 22 6.477 22 2 17.52 2 12S6.477 2 12 2c3.272 0 6.176 1.57 8 4V3.5h2v6h-6v-2h2.616C17.175 5.39 14.749 4 12 4z'

--- a/src/__tests__/utils/page-test-utils.ts
+++ b/src/__tests__/utils/page-test-utils.ts
@@ -43,8 +43,8 @@ export function setupFailedPageDOM(): void {
   const div = document.createElement('div')
   div.className = FAILED_PAGE_CLASS
 
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+  const svg = document.createElementNS('https://www.w3.org/2000/svg', 'svg')
+  const path = document.createElementNS('https://www.w3.org/2000/svg', 'path')
   path.setAttribute(
     'd',
     'M12 4c-4.418 0-8 3.58-8 8s3.582 8 8 8c3.806 0 6.993-2.66 7.802-6.22l1.95.44C20.742 18.67 16.76 22 12 22 6.477 22 2 17.52 2 12S6.477 2 12 2c3.272 0 6.176 1.57 8 4V3.5h2v6h-6v-2h2.616C17.175 5.39 14.749 4 12 4z'

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -107,7 +107,7 @@ export const ConfigManager = {
   getAuthWebhookUrl(): string {
     const authUrl = GM_getValue('authWebhookUrl', '')
 
-    return authUrl || this.getDiscordWebhookUrl()
+    return authUrl || ConfigManager.getDiscordWebhookUrl()
   },
 
   /**
@@ -128,7 +128,7 @@ export const ConfigManager = {
   getLockWebhookUrl(): string {
     const lockUrl = GM_getValue('lockWebhookUrl', '')
 
-    return lockUrl || this.getDiscordWebhookUrl()
+    return lockUrl || ConfigManager.getDiscordWebhookUrl()
   },
 
   /**

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -8,189 +8,290 @@ import type { StorageData, StorageKey, Tweet } from '@/types'
  * - チェック済み/待機中ツイートIDにSetを使用してO(1)ルックアップを実現
  * - 保存済みツイートにMapを使用して効率的な更新を実現
  */
-export const Storage = {
-  // キャッシュ用のプライベートプロパティ
-  _checkedTweetsSet: null as Set<string> | null,
-  _waitingTweetsSet: null as Set<string> | null,
-  _savedTweetsMap: null as Map<string, Tweet> | null,
-  getValue<K extends StorageKey>(
+export class Storage {
+  /** チェック済みツイートIDのキャッシュ */
+  private static _checkedTweetsSet: Set<string> | null = null
+  /** 待機中ツイートIDのキャッシュ */
+  private static _waitingTweetsSet: Set<string> | null = null
+  /** 保存済みツイートのキャッシュ */
+  private static _savedTweetsMap: Map<string, Tweet> | null = null
+
+  /**
+   * ストレージから値を取得する
+   *
+   * @param key - 取得するキー
+   * @param defaultValue - デフォルト値
+   * @returns 取得した値
+   */
+  static getValue<K extends StorageKey>(
     key: K,
     defaultValue: StorageData[K]
   ): StorageData[K] {
     return GM_getValue(key, defaultValue)
-  },
+  }
 
-  setValue<K extends StorageKey>(key: K, value: StorageData[K]): void {
+  /**
+   * ストレージに値を保存する
+   *
+   * @param key - 保存するキー
+   * @param value - 保存する値
+   */
+  static setValue<K extends StorageKey>(key: K, value: StorageData[K]): void {
     GM_setValue(key, value)
-  },
+  }
 
-  getCheckedTweets(): string[] {
-    return this.getValue('checkedTweets', [])
-  },
+  /**
+   * チェック済みツイートIDの配列を取得する
+   *
+   * @returns チェック済みツイートIDの配列
+   */
+  static getCheckedTweets(): string[] {
+    return Storage.getValue('checkedTweets', [])
+  }
 
   /**
    * チェック済みツイートIDのSetを取得（キャッシュ付き）
    * O(1)ルックアップのための最適化
+   *
+   * @returns チェック済みツイートIDのSet
    */
-  getCheckedTweetsSet(): Set<string> {
-    this._checkedTweetsSet ??= new Set(this.getCheckedTweets())
-    return this._checkedTweetsSet
-  },
+  static getCheckedTweetsSet(): Set<string> {
+    Storage._checkedTweetsSet ??= new Set(Storage.getCheckedTweets())
+    return Storage._checkedTweetsSet
+  }
 
-  getWaitingTweets(): string[] {
-    return this.getValue('waitingTweets', [])
-  },
+  /**
+   * 待機中ツイートIDの配列を取得する
+   *
+   * @returns 待機中ツイートIDの配列
+   */
+  static getWaitingTweets(): string[] {
+    return Storage.getValue('waitingTweets', [])
+  }
 
   /**
    * 待機中ツイートIDのSetを取得（キャッシュ付き）
    * O(1)ルックアップのための最適化
+   *
+   * @returns 待機中ツイートIDのSet
    */
-  getWaitingTweetsSet(): Set<string> {
-    this._waitingTweetsSet ??= new Set(this.getWaitingTweets())
-    return this._waitingTweetsSet
-  },
+  static getWaitingTweetsSet(): Set<string> {
+    Storage._waitingTweetsSet ??= new Set(Storage.getWaitingTweets())
+    return Storage._waitingTweetsSet
+  }
 
-  getSavedTweets() {
-    return this.getValue('savedTweets', [])
-  },
+  /**
+   * 保存済みツイートの配列を取得する
+   *
+   * @returns 保存済みツイートの配列
+   */
+  static getSavedTweets() {
+    return Storage.getValue('savedTweets', [])
+  }
 
   /**
    * 保存済みツイートのMapを取得（キャッシュ付き）
    * O(1)ルックアップと更新のための最適化
+   *
+   * @returns 保存済みツイートのMap（キー: tweetId）
    */
-  getSavedTweetsMap(): Map<string, Tweet> {
-    this._savedTweetsMap ??= new Map(
-      this.getSavedTweets().map((tweet) => [tweet.tweetId, tweet])
+  static getSavedTweetsMap(): Map<string, Tweet> {
+    Storage._savedTweetsMap ??= new Map(
+      Storage.getSavedTweets().map((tweet) => [tweet.tweetId, tweet])
     )
-    return this._savedTweetsMap
-  },
+    return Storage._savedTweetsMap
+  }
 
-  isLoginNotified(): boolean {
-    return this.getValue('isLoginNotified', false)
-  },
+  /**
+   * ログイン通知済みかどうかを取得する
+   *
+   * @returns ログイン通知済みの場合 true
+   */
+  static isLoginNotified(): boolean {
+    return Storage.getValue('isLoginNotified', false)
+  }
 
-  isLockedNotified(): boolean {
-    return this.getValue('isLockedNotified', false)
-  },
+  /**
+   * ロック通知済みかどうかを取得する
+   *
+   * @returns ロック通知済みの場合 true
+   */
+  static isLockedNotified(): boolean {
+    return Storage.getValue('isLockedNotified', false)
+  }
 
-  getRetryCount(): number {
-    return this.getValue('retryCount', 0)
-  },
+  /**
+   * リトライ回数を取得する
+   *
+   * @returns 現在のリトライ回数
+   */
+  static getRetryCount(): number {
+    return Storage.getValue('retryCount', 0)
+  }
 
-  setCheckedTweets(tweets: string[]): void {
-    this.setValue('checkedTweets', tweets)
+  /**
+   * チェック済みツイートIDの配列を保存する
+   *
+   * @param tweets - 保存するツイートIDの配列
+   */
+  static setCheckedTweets(tweets: string[]): void {
+    Storage.setValue('checkedTweets', tweets)
     // キャッシュを更新
-    this._checkedTweetsSet = new Set(tweets)
-  },
+    Storage._checkedTweetsSet = new Set(tweets)
+  }
 
-  setWaitingTweets(tweets: string[]): void {
-    this.setValue('waitingTweets', tweets)
+  /**
+   * 待機中ツイートIDの配列を保存する
+   *
+   * @param tweets - 保存するツイートIDの配列
+   */
+  static setWaitingTweets(tweets: string[]): void {
+    Storage.setValue('waitingTweets', tweets)
     // キャッシュを更新
-    this._waitingTweetsSet = new Set(tweets)
-  },
+    Storage._waitingTweetsSet = new Set(tweets)
+  }
 
-  setSavedTweets(tweets: StorageData['savedTweets']): void {
-    this.setValue('savedTweets', tweets)
+  /**
+   * 保存済みツイートの配列を保存する
+   *
+   * @param tweets - 保存するツイートの配列
+   */
+  static setSavedTweets(tweets: StorageData['savedTweets']): void {
+    Storage.setValue('savedTweets', tweets)
     // キャッシュを更新
-    this._savedTweetsMap = new Map(
+    Storage._savedTweetsMap = new Map(
       tweets.map((tweet) => [tweet.tweetId, tweet])
     )
-  },
+  }
 
-  setLoginNotified(value: boolean): void {
-    this.setValue('isLoginNotified', value)
-  },
+  /**
+   * ログイン通知済みフラグを保存する
+   *
+   * @param value - 保存する値
+   */
+  static setLoginNotified(value: boolean): void {
+    Storage.setValue('isLoginNotified', value)
+  }
 
-  setLockedNotified(value: boolean): void {
-    this.setValue('isLockedNotified', value)
-  },
+  /**
+   * ロック通知済みフラグを保存する
+   *
+   * @param value - 保存する値
+   */
+  static setLockedNotified(value: boolean): void {
+    Storage.setValue('isLockedNotified', value)
+  }
 
-  setRetryCount(count: number): void {
-    this.setValue('retryCount', count)
-  },
+  /**
+   * リトライ回数を保存する
+   *
+   * @param count - 保存するリトライ回数
+   */
+  static setRetryCount(count: number): void {
+    Storage.setValue('retryCount', count)
+  }
 
-  getStoredVersion(): string {
-    return this.getValue('storedVersion', '')
-  },
+  /**
+   * 保存済みバージョンを取得する
+   *
+   * @returns 保存済みバージョン文字列
+   */
+  static getStoredVersion(): string {
+    return Storage.getValue('storedVersion', '')
+  }
 
-  setStoredVersion(version: string): void {
-    this.setValue('storedVersion', version)
-  },
+  /**
+   * バージョンを保存する
+   *
+   * @param version - 保存するバージョン文字列
+   */
+  static setStoredVersion(version: string): void {
+    Storage.setValue('storedVersion', version)
+  }
 
   /**
    * キャッシュをクリア（主にテスト用）
    */
-  clearCache(): void {
-    this._checkedTweetsSet = null
-    this._waitingTweetsSet = null
-    this._savedTweetsMap = null
-  },
+  static clearCache(): void {
+    Storage._checkedTweetsSet = null
+    Storage._waitingTweetsSet = null
+    Storage._savedTweetsMap = null
+  }
 
   /**
    * バッチ処理: 複数のツイートIDを一度にチェック済みに追加
+   *
    * @param tweetIds - 追加するツイートIDの配列
    */
-  addCheckedTweetsBatch(tweetIds: string[]): void {
-    const checkedTweetsSet = this.getCheckedTweetsSet()
+  static addCheckedTweetsBatch(tweetIds: string[]): void {
+    const checkedTweetsSet = Storage.getCheckedTweetsSet()
     for (const tweetId of tweetIds) {
       checkedTweetsSet.add(tweetId)
     }
-    this.setCheckedTweets([...checkedTweetsSet])
-  },
+    Storage.setCheckedTweets([...checkedTweetsSet])
+  }
 
   /**
    * バッチ処理: 複数のツイートIDを一度に待機中に追加
+   *
    * @param tweetIds - 追加するツイートIDの配列
    */
-  addWaitingTweetsBatch(tweetIds: string[]): void {
-    const waitingTweetsSet = this.getWaitingTweetsSet()
+  static addWaitingTweetsBatch(tweetIds: string[]): void {
+    const waitingTweetsSet = Storage.getWaitingTweetsSet()
     for (const tweetId of tweetIds) {
       waitingTweetsSet.add(tweetId)
     }
-    this.setWaitingTweets([...waitingTweetsSet])
-  },
+    Storage.setWaitingTweets([...waitingTweetsSet])
+  }
 
   /**
    * バッチ処理: 複数のツイートを一度に保存
+   *
    * @param tweets - 保存するツイートの配列
    */
-  saveTweetsBatch(tweets: Tweet[]): void {
-    const savedTweetsMap = this.getSavedTweetsMap()
+  static saveTweetsBatch(tweets: Tweet[]): void {
+    const savedTweetsMap = Storage.getSavedTweetsMap()
     for (const tweet of tweets) {
       savedTweetsMap.set(tweet.tweetId, tweet)
     }
     const sortedTweets = [...savedTweetsMap.values()].toSorted((a, b) =>
       a.tweetId.localeCompare(b.tweetId)
     )
-    this.setSavedTweets(sortedTweets)
-  },
+    Storage.setSavedTweets(sortedTweets)
+  }
 
   /**
    * 特定のツイートIDがチェック済みか待機中かを一度にチェック
+   *
    * @param tweetId - チェックするツイートID
-   * @returns {チェック済み: boolean, 待機中: boolean}
+   * @returns チェック済みと待機中の状態を含むオブジェクト
    */
-  getTweetStatus(tweetId: string): { isChecked: boolean; isWaiting: boolean } {
+  static getTweetStatus(tweetId: string): {
+    isChecked: boolean
+    isWaiting: boolean
+  } {
     return {
-      isChecked: this.getCheckedTweetsSet().has(tweetId),
-      isWaiting: this.getWaitingTweetsSet().has(tweetId),
+      isChecked: Storage.getCheckedTweetsSet().has(tweetId),
+      isWaiting: Storage.getWaitingTweetsSet().has(tweetId),
     }
-  },
+  }
 
   /**
    * 保存済みツイートから特定のIDで検索
+   *
    * @param tweetId - 検索するツイートID
    * @returns ツイートオブジェクトまたはundefined
    */
-  getSavedTweetById(tweetId: string): Tweet | undefined {
-    return this.getSavedTweetsMap().get(tweetId)
-  },
+  static getSavedTweetById(tweetId: string): Tweet | undefined {
+    return Storage.getSavedTweetsMap().get(tweetId)
+  }
 
   /**
    * ストレージの統計情報を取得
-   * @returns ストレージの統計情報
+   *
+   * @returns ストレージの統計情報（件数とメモリ使用状況）
    */
-  getStorageStats(): {
+  static getStorageStats(): {
     checkedTweetsCount: number
     waitingTweetsCount: number
     savedTweetsCount: number
@@ -201,14 +302,14 @@ export const Storage = {
     }
   } {
     return {
-      checkedTweetsCount: this.getCheckedTweetsSet().size,
-      waitingTweetsCount: this.getWaitingTweetsSet().size,
-      savedTweetsCount: this.getSavedTweetsMap().size,
+      checkedTweetsCount: Storage.getCheckedTweetsSet().size,
+      waitingTweetsCount: Storage.getWaitingTweetsSet().size,
+      savedTweetsCount: Storage.getSavedTweetsMap().size,
       memoryUsage: {
-        checkedTweetsSetSize: this._checkedTweetsSet?.size ?? 0,
-        waitingTweetsSetSize: this._waitingTweetsSet?.size ?? 0,
-        savedTweetsMapSize: this._savedTweetsMap?.size ?? 0,
+        checkedTweetsSetSize: Storage._checkedTweetsSet?.size ?? 0,
+        waitingTweetsSetSize: Storage._waitingTweetsSet?.size ?? 0,
+        savedTweetsMapSize: Storage._savedTweetsMap?.size ?? 0,
       },
     }
-  },
+  }
 }

--- a/src/pages/other-pages.ts
+++ b/src/pages/other-pages.ts
@@ -3,7 +3,13 @@ import { Storage } from '@/core/storage'
 import { AsyncUtils } from '@/utils/async'
 import { PageErrorHandler } from '@/utils/page-error-handler'
 
+/**
+ * ツイートページ以外のページ処理を担当するクラス
+ */
 export const OtherPages = {
+  /**
+   * 投稿作成ページから戻る処理を実行する
+   */
   runComposePost(): void {
     const closeButton = document.querySelector(
       'button[data-testid="app-bar-close"][role="button"]'
@@ -15,7 +21,7 @@ export const OtherPages = {
   },
 
   /**
-   * ロック解除検知のための定期チェックを開始
+   * ロック解除検知のための定期チェックを開始する
    */
   startPeriodicUnlockCheck(): void {
     let checkCount = 0
@@ -30,6 +36,11 @@ export const OtherPages = {
     }, DELAYS.LOCKED_CHECK_INTERVAL)
   },
 
+  /**
+   * Blue Blocker キューの処理ページを実行する
+   *
+   * @returns {Promise<void>} 処理完了を表すPromise
+   */
   async runProcessBlueBlockerQueue(): Promise<void> {
     PageErrorHandler.logAction('start')
 
@@ -55,6 +66,9 @@ export const OtherPages = {
     }, DELAYS.CRAWL_INTERVAL)
   },
 
+  /**
+   * ログインページの処理を実行する
+   */
   runLogin(): void {
     const isLoginNotified = Storage.isLoginNotified()
     if (isLoginNotified) {
@@ -63,6 +77,12 @@ export const OtherPages = {
     window.open(URLS.EXAMPLE_LOGIN_NOTIFY, '_blank')
   },
 
+  /**
+   * アカウントロック時の処理を実行する
+   *
+   * 未通知の場合はロック通知ウィンドウを開き、
+   * ロック解除検知のための定期チェックを開始する。
+   */
   runLocked(): void {
     PageErrorHandler.logAction(
       'Account is locked, starting continuous unlock detection'
@@ -71,7 +91,7 @@ export const OtherPages = {
     const isLockedNotified = Storage.isLockedNotified()
     if (isLockedNotified) {
       // 既に通知済みの場合は、定期チェックのみ開始
-      this.startPeriodicUnlockCheck()
+      OtherPages.startPeriodicUnlockCheck()
       return
     }
 
@@ -80,6 +100,6 @@ export const OtherPages = {
     window.open(URLS.EXAMPLE_LOCKED_NOTIFY, '_blank')
 
     // ロック解除検知のための定期チェックを開始
-    this.startPeriodicUnlockCheck()
+    OtherPages.startPeriodicUnlockCheck()
   },
 }

--- a/src/services/version-service.ts
+++ b/src/services/version-service.ts
@@ -6,7 +6,8 @@ import { Storage } from '@/core/storage'
 export const VersionService = {
   /**
    * 現在のスクリプトバージョンをチェックし、変更があればDiscordに通知する
-   * @param currentVersion 現在のスクリプトバージョン
+   *
+   * @param currentVersion - 現在のスクリプトバージョン
    */
   checkVersionAndNotify(currentVersion: string): void {
     const storedVersion = Storage.getStoredVersion()
@@ -23,7 +24,7 @@ export const VersionService = {
       )
 
       try {
-        this.notifyVersionUpdate(storedVersion, currentVersion)
+        VersionService.notifyVersionUpdate(storedVersion, currentVersion)
         Storage.setStoredVersion(currentVersion)
         console.log(
           'VersionService: Update notification sent and version updated'

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -57,7 +57,7 @@ export const AsyncUtils = {
     signal?: AbortSignal
   ): Promise<void> {
     const durationMs = Math.random() * (maxMs - minMs) + minMs
-    return this.delay(durationMs, signal)
+    return AsyncUtils.delay(durationMs, signal)
   },
 
   /**
@@ -90,7 +90,7 @@ export const AsyncUtils = {
     signal?: AbortSignal
   ): Promise<void> {
     const backoffMs = Math.min(baseMs * Math.pow(2, attempt), maxMs)
-    return this.delay(backoffMs, signal)
+    return AsyncUtils.delay(backoffMs, signal)
   },
 
   /**
@@ -166,8 +166,8 @@ export const AsyncUtils = {
         }
 
         await (useExponentialBackoff
-          ? this.exponentialBackoff(baseDelay, attempt, 30_000, signal)
-          : this.delay(baseDelay, signal))
+          ? AsyncUtils.exponentialBackoff(baseDelay, attempt, 30_000, signal)
+          : AsyncUtils.delay(baseDelay, signal))
       }
     }
 
@@ -176,9 +176,14 @@ export const AsyncUtils = {
   },
 }
 
+/** リトライ処理のオプション */
 export interface RetryOptions {
+  /** 最大試行回数（デフォルト: 3） */
   maxAttempts?: number
+  /** 基本遅延時間（ミリ秒、デフォルト: 1000） */
   baseDelay?: number
+  /** 指数バックオフを使用するか（デフォルト: true） */
   useExponentialBackoff?: boolean
+  /** キャンセル用 AbortSignal */
   signal?: AbortSignal
 }

--- a/src/utils/page-error-handler.ts
+++ b/src/utils/page-error-handler.ts
@@ -3,36 +3,36 @@ import { DomUtils } from '@/utils/dom'
 import { AsyncUtils } from '@/utils/async'
 
 /**
- * Options for page error handling
+ * ページエラーハンドリングのオプション
  */
 export interface PageErrorOptions {
-  /** Whether to reload the page after error (default: true) */
+  /** エラー後にページをリロードするか（デフォルト: true） */
   shouldReload?: boolean
-  /** Wait time before reload in milliseconds (default: DELAYS.ERROR_RELOAD_WAIT) */
+  /** リロード前の待機時間（ミリ秒、デフォルト: DELAYS.ERROR_RELOAD_WAIT） */
   waitTime?: number
-  /** Custom error message to display instead of default */
+  /** デフォルトの代わりに表示するカスタムエラーメッセージ */
   customMessage?: string
 }
 
 /**
- * Common error handler for page components
+ * ページコンポーネント共通のエラーハンドラー
  *
- * Provides standardized error handling across all page components,
- * including failed page detection, logging, and reload functionality.
+ * 全ページコンポーネントで標準化されたエラーハンドリングを提供する。
+ * 失敗ページの検出、ログ出力、リロード機能を含む。
  */
 export const PageErrorHandler = {
   /**
-   * Handle page errors with standard logging and reload behavior
+   * 標準的なログ出力とリロード動作でページエラーを処理する
    *
-   * @param pageName - Name of the page for logging (e.g., 'Home', 'Search')
-   * @param methodName - Name of the method where error occurred (auto-detected if not provided)
-   * @param error - The error that was caught
-   * @param options - Error handling options
-   * @returns Promise that resolves after handling the error
+   * @param pageName - ログ用のページ名（例: 'Home', 'Search'）
+   * @param methodNameOrError - メソッド名（文字列）またはエラーオブジェクト（自動検出時）
+   * @param errorOrOptions - エラーオブジェクトまたはオプション
+   * @param optionsArg - エラーハンドリングオプション
+   * @returns エラー処理完了を表すPromise
    *
    * @example
    * ```typescript
-   * // With auto-detection (recommended)
+   * // 自動検出（推奨）
    * try {
    *   await DomUtils.waitElement('.timeline')
    * } catch (error) {
@@ -40,7 +40,7 @@ export const PageErrorHandler = {
    *   return
    * }
    *
-   * // With manual method name
+   * // メソッド名を手動指定
    * try {
    *   await DomUtils.waitElement('.timeline')
    * } catch (error) {
@@ -55,19 +55,19 @@ export const PageErrorHandler = {
     errorOrOptions?: any,
     optionsArg?: PageErrorOptions
   ): Promise<void> {
-    // Handle overloaded parameters
+    // オーバーロードされたパラメータを処理する
     let methodName: string
     let error: unknown
     let options: PageErrorOptions
 
     if (typeof methodNameOrError === 'string') {
-      // Old signature: handlePageError(pageName, methodName, error, options)
+      // 旧シグネチャ: handlePageError(pageName, methodName, error, options)
       methodName = methodNameOrError
       error = errorOrOptions
       options = optionsArg ?? {}
     } else {
-      // New signature: handlePageError(pageName, error, options)
-      methodName = this._getCallerName()
+      // 新シグネチャ: handlePageError(pageName, error, options)
+      methodName = PageErrorHandler._getCallerName()
       error = methodNameOrError
       options =
         errorOrOptions !== undefined &&
@@ -83,19 +83,19 @@ export const PageErrorHandler = {
       customMessage,
     } = options
 
-    // Check if this is a failed page
+    // 失敗ページかどうかチェック
     if (DomUtils.isFailedPage()) {
       console.error(`${methodName}: failed page.`)
     }
 
-    // Log the error with page name
+    // ページ名付きでエラーをログ出力
     console.error(`${methodName} (${pageName}):`, error)
 
-    // Log the error message
+    // エラーメッセージをログ出力
     const message = customMessage ?? 'Wait 1 minute and reload.'
     console.log(message)
 
-    // Wait and reload if needed
+    // 必要に応じて待機してリロード
     if (shouldReload) {
       await AsyncUtils.delay(waitTime)
       location.reload()
@@ -103,25 +103,25 @@ export const PageErrorHandler = {
   },
 
   /**
-   * Wait for an element with standard error handling
+   * 標準的なエラーハンドリングで要素を待機する
    *
-   * Wraps DomUtils.waitElement with automatic error handling and reload logic.
+   * DomUtils.waitElement を自動エラーハンドリングとリロードロジックでラップする。
    *
-   * @param selector - CSS selector for the element
-   * @param pageName - Name of the page for logging
-   * @param methodName - Name of the method for logging (auto-detected if not provided)
-   * @param options - Additional options including timeout and error handling
-   * @returns Promise that resolves when element is found or rejects after handling error
+   * @param selector - 要素のCSSセレクター
+   * @param pageName - ログ用のページ名
+   * @param methodNameOrOptions - メソッド名（文字列）またはオプション（自動検出時）
+   * @param optionsArg - タイムアウトとエラーハンドリングを含む追加オプション
+   * @returns 要素が見つかった場合に解決するPromise、エラー処理後にリジェクト
    *
    * @example
    * ```typescript
-   * // With auto-detection (recommended)
+   * // 自動検出（推奨）
    * await PageErrorHandler.waitForElementWithErrorHandling(
    *   '[role="main"]',
    *   'Home'
    * )
    *
-   * // With manual method name
+   * // メソッド名を手動指定
    * await PageErrorHandler.waitForElementWithErrorHandling(
    *   '[role="main"]',
    *   'Home',
@@ -143,7 +143,7 @@ export const PageErrorHandler = {
       errorOptions?: PageErrorOptions
     }
   ): Promise<HTMLElement> {
-    // Handle overloaded parameters
+    // オーバーロードされたパラメータを処理する
     let methodName: string
     let options: {
       timeout?: number
@@ -151,62 +151,62 @@ export const PageErrorHandler = {
     }
 
     if (typeof methodNameOrOptions === 'string') {
-      // Old signature: waitForElementWithErrorHandling(selector, pageName, methodName, options)
+      // 旧シグネチャ: waitForElementWithErrorHandling(selector, pageName, methodName, options)
       methodName = methodNameOrOptions
       options = optionsArg ?? {}
     } else {
-      // New signature: waitForElementWithErrorHandling(selector, pageName, options)
-      methodName = this._getCallerName()
+      // 新シグネチャ: waitForElementWithErrorHandling(selector, pageName, options)
+      methodName = PageErrorHandler._getCallerName()
       options = methodNameOrOptions ?? {}
     }
 
     try {
       await DomUtils.waitElement(selector, options.timeout)
-      // DomUtils.waitElement doesn't return the element, so we need to query for it
+      // DomUtils.waitElement は要素を返さないため、queryで取得する
       const element = document.querySelector(selector)
       if (!element) {
         throw new Error(`Element ${selector} not found after waiting`)
       }
       return element as HTMLElement
     } catch (error) {
-      await this.handlePageError(
+      await PageErrorHandler.handlePageError(
         pageName,
         methodName,
         error,
         options.errorOptions
       )
-      throw error // Re-throw to maintain control flow
+      throw error // 制御フローを維持するために再スロー
     }
   },
 
   /**
-   * Execute a page operation with error handling
+   * エラーハンドリング付きでページ操作を実行する
    *
-   * Wraps any async operation with standard error handling.
-   * Useful for operations beyond element waiting.
+   * 任意の非同期操作を標準エラーハンドリングでラップする。
+   * 要素待機以外の操作に対して有効。
    *
-   * @param operation - The async operation to execute
-   * @param pageName - Name of the page for logging
-   * @param methodName - Name of the method for logging (auto-detected if not provided)
-   * @param options - Error handling options
-   * @returns Promise that resolves with operation result or undefined after error handling
+   * @param operation - 実行する非同期操作
+   * @param pageName - ログ用のページ名
+   * @param methodNameOrOptions - メソッド名（文字列）またはオプション（自動検出時）
+   * @param optionsArg - エラーハンドリングオプション
+   * @returns 操作結果またはエラー処理後にundefinedを返すPromise
    *
    * @example
    * ```typescript
-   * // With auto-detection (recommended)
+   * // 自動検出（推奨）
    * await PageErrorHandler.executeWithErrorHandling(
    *   async () => {
-   *     // Complex page operations
+   *     // 複雑なページ操作
    *     const element = await DomUtils.waitElement('.timeline')
    *     await processElement(element)
    *   },
    *   'Home'
    * )
    *
-   * // With manual method name
+   * // メソッド名を手動指定
    * await PageErrorHandler.executeWithErrorHandling(
    *   async () => {
-   *     // Complex page operations
+   *     // 複雑なページ操作
    *     const element = await DomUtils.waitElement('.timeline')
    *     await processElement(element)
    *   },
@@ -221,48 +221,53 @@ export const PageErrorHandler = {
     methodNameOrOptions?: string | PageErrorOptions,
     optionsArg?: PageErrorOptions
   ): Promise<T | undefined> {
-    // Handle overloaded parameters
+    // オーバーロードされたパラメータを処理する
     let methodName: string
     let options: PageErrorOptions
 
     if (typeof methodNameOrOptions === 'string') {
-      // Old signature: executeWithErrorHandling(operation, pageName, methodName, options)
+      // 旧シグネチャ: executeWithErrorHandling(operation, pageName, methodName, options)
       methodName = methodNameOrOptions
       options = optionsArg ?? {}
     } else {
-      // New signature: executeWithErrorHandling(operation, pageName, options)
-      methodName = this._getCallerName()
+      // 新シグネチャ: executeWithErrorHandling(operation, pageName, options)
+      methodName = PageErrorHandler._getCallerName()
       options = methodNameOrOptions ?? {}
     }
 
     try {
       return await operation()
     } catch (error) {
-      await this.handlePageError(pageName, methodName, error, options)
+      await PageErrorHandler.handlePageError(
+        pageName,
+        methodName,
+        error,
+        options
+      )
       return undefined
     }
   },
 
   /**
-   * Log the start of page processing
+   * ページ処理の開始をログ出力する
    *
-   * Provides consistent logging format across all pages.
+   * 全ページで一貫したログフォーマットを提供する。
    *
-   * @param pageName - Name of the page
-   * @param methodName - Name of the method (auto-detected if not provided)
-   * @param additionalInfo - Optional additional information to log
+   * @param pageName - ページ名
+   * @param methodNameOrAdditionalInfo - メソッド名（文字列）または追加情報（自動検出時）
+   * @param additionalInfoArg - オプションの追加情報
    *
    * @example
    * ```typescript
-   * // With auto-detection (recommended)
+   * // 自動検出（推奨）
    * PageErrorHandler.logPageStart('Home', { userId: '12345' })
-   * // Logs: "runHome: Starting Home page processing..." (auto-detected from stack)
-   * // Logs: "runHome: Additional info: { userId: '12345' }"
+   * // ログ: "runHome: Starting Home page processing..." （スタックから自動検出）
+   * // ログ: "runHome: Additional info: { userId: '12345' }"
    *
-   * // With manual method name
+   * // メソッド名を手動指定
    * PageErrorHandler.logPageStart('Home', 'runHome', { userId: '12345' })
-   * // Logs: "runHome: Starting Home page processing..."
-   * // Logs: "runHome: Additional info: { userId: '12345' }"
+   * // ログ: "runHome: Starting Home page processing..."
+   * // ログ: "runHome: Additional info: { userId: '12345' }"
    * ```
    */
   logPageStart(
@@ -270,17 +275,17 @@ export const PageErrorHandler = {
     methodNameOrAdditionalInfo?: string | Record<string, any>,
     additionalInfoArg?: Record<string, any>
   ): void {
-    // Handle overloaded parameters
+    // オーバーロードされたパラメータを処理する
     let methodName: string
     let additionalInfo: Record<string, any> | undefined
 
     if (typeof methodNameOrAdditionalInfo === 'string') {
-      // Old signature: logPageStart(pageName, methodName, additionalInfo)
+      // 旧シグネチャ: logPageStart(pageName, methodName, additionalInfo)
       methodName = methodNameOrAdditionalInfo
       additionalInfo = additionalInfoArg
     } else {
-      // New signature: logPageStart(pageName, additionalInfo)
-      methodName = this._getCallerName()
+      // 新シグネチャ: logPageStart(pageName, additionalInfo)
+      methodName = PageErrorHandler._getCallerName()
       additionalInfo = methodNameOrAdditionalInfo
     }
 
@@ -292,53 +297,53 @@ export const PageErrorHandler = {
   },
 
   /**
-   * Log page action with consistent format
+   * 一貫したフォーマットでページアクションをログ出力する
    *
-   * Automatically detects the calling function name from the stack trace.
-   * You can optionally provide a custom method name to override the detection.
+   * スタックトレースから呼び出し元関数名を自動検出する。
+   * オプションでカスタムメソッド名を指定して検出を上書きできる。
    *
-   * @param action - Description of the action
-   * @param methodName - Optional custom method name (auto-detected if not provided)
+   * @param action - アクションの説明
+   * @param methodName - オプションのカスタムメソッド名（未指定時は自動検出）
    *
    * @example
    * ```typescript
-   * // Auto-detection (recommended)
+   * // 自動検出（推奨）
    * PageErrorHandler.logAction('Found 10 new tweets')
-   * // Logs: "runHome: Found 10 new tweets" (auto-detected from stack)
+   * // ログ: "runHome: Found 10 new tweets" （スタックから自動検出）
    *
-   * // Manual override
+   * // 手動上書き
    * PageErrorHandler.logAction('Found 10 new tweets', 'customMethod')
-   * // Logs: "customMethod: Found 10 new tweets"
+   * // ログ: "customMethod: Found 10 new tweets"
    * ```
    */
   logAction(action: string, methodName?: string): void {
-    const callerName = methodName ?? this._getCallerName()
+    const callerName = methodName ?? PageErrorHandler._getCallerName()
     console.log(`${callerName}: ${action}`)
   },
 
   /**
-   * Log error with consistent format
+   * 一貫したフォーマットでエラーをログ出力する
    *
-   * Automatically detects the calling function name from the stack trace.
-   * You can optionally provide a custom method name to override the detection.
+   * スタックトレースから呼び出し元関数名を自動検出する。
+   * オプションでカスタムメソッド名を指定して検出を上書きできる。
    *
-   * @param errorMessage - Error message to log
-   * @param error - Optional error object for additional details
-   * @param methodName - Optional custom method name (auto-detected if not provided)
+   * @param errorMessage - ログ出力するエラーメッセージ
+   * @param error - 追加詳細用のオプションのエラーオブジェクト
+   * @param methodName - オプションのカスタムメソッド名（未指定時は自動検出）
    *
    * @example
    * ```typescript
-   * // Auto-detection (recommended)
+   * // 自動検出（推奨）
    * PageErrorHandler.logError('Failed to process timeline', error)
-   * // Logs: "runHome: Failed to process timeline" (auto-detected from stack)
+   * // ログ: "runHome: Failed to process timeline" （スタックから自動検出）
    *
-   * // Manual override
+   * // 手動上書き
    * PageErrorHandler.logError('Failed to process timeline', error, 'customMethod')
-   * // Logs: "customMethod: Failed to process timeline"
+   * // ログ: "customMethod: Failed to process timeline"
    * ```
    */
   logError(errorMessage: string, error?: unknown, methodName?: string): void {
-    const callerName = methodName ?? this._getCallerName()
+    const callerName = methodName ?? PageErrorHandler._getCallerName()
     console.error(`${callerName}: ${errorMessage}`)
 
     if (error && process.env.NODE_ENV === 'development') {
@@ -347,9 +352,9 @@ export const PageErrorHandler = {
   },
 
   /**
-   * Extract caller function name from stack trace
+   * スタックトレースから呼び出し元関数名を取得する
    *
-   * @returns The name of the calling function, or 'unknown' if not detectable
+   * @returns 呼び出し元関数名。検出できない場合は 'unknown'
    * @private
    */
   _getCallerName(): string {
@@ -357,14 +362,14 @@ export const PageErrorHandler = {
       const stack = new Error('Stack trace generation').stack
       if (!stack) return 'unknown'
 
-      // Split stack trace into lines
+      // スタックトレースを行に分割
       const stackLines = stack.split('\n')
 
-      // Look for the caller (skip Error(), this method, and logAction/logError)
+      // 呼び出し元を探す（Error()、このメソッド、logAction/logError をスキップ）
       for (let i = 3; i < stackLines.length; i++) {
         const line = stackLines[i]
 
-        // Match function names in various formats:
+        // 各フォーマットの関数名にマッチ:
         // - "at functionName (...)"
         // - "at Object.functionName (...)"
         // - "at ClassName.functionName (...)"


### PR DESCRIPTION
## Summary

`@book000/eslint-config` を v1.14.55 → v1.14.61 に更新し、`eslint-plugin-unicorn` v65 系で新たに有効化されたルール違反を修正します。

## Changes

### `@book000/eslint-config` バージョン更新

- v1.14.55 → v1.14.61
- v1.14.60 で `__tests__` / `__mocks__` ディレクトリの `unicorn/filename-case` 除外が追加済みのため、その 23 件は本 PR 対応不要

### unicorn/no-this-outside-of-class (61 件) の修正

`unicorn/no-static-only-class` ルール（static メソッドのみのクラスを禁止）との競合により、変換方針をファイルごとに使い分けています。

#### Storage クラス化（`src/core/storage.ts`）

private static キャッシュフィールド（`_checkedTweetsSet` 等）を持つため `unicorn/no-static-only-class` の対象外。`export class Storage { static ... }` 形式に変換し、`this` 参照をすべて `Storage` に置換。

#### オブジェクトリテラル内での this 参照をオブジェクト名に置換

`unicorn/no-static-only-class` により static only クラスへの変換が ESLint auto-fix で戻されるため、オブジェクトリテラル形式のまま `this` をオブジェクト名への直接参照に変換:

- `src/core/config.ts`: `ConfigManager` 内の `this.getDiscordWebhookUrl()` → `ConfigManager.getDiscordWebhookUrl()`
- `src/pages/other-pages.ts`: `OtherPages` 内の `this.startPeriodicUnlockCheck()` → `OtherPages.startPeriodicUnlockCheck()`
- `src/services/version-service.ts`: `VersionService` 内の `this.notifyVersionUpdate()` → `VersionService.notifyVersionUpdate()`
- `src/utils/async.ts`: `AsyncUtils` 内の `this.delay()` / `this.exponentialBackoff()` → `AsyncUtils` 名参照に変換
- `src/utils/page-error-handler.ts`: `PageErrorHandler` 内の `this._getCallerName()` / `this.handlePageError()` 等 → `PageErrorHandler` 名参照に変換

### unicorn/prefer-https (4 件) の修正

SVG namespace URI (`http://www.w3.org/2000/svg`) は W3C 仕様上 `http://` で定義された識別子であり `https://` に変更すると別 namespace として扱われる。`http://` のまま維持し、`eslint-disable` ブロックで明示的に抑制:

- `src/__tests__/utils/dom.test.ts`
- `src/__tests__/utils/page-test-utils.ts`

### unicorn/no-array-from-fill / unicorn/no-array-fill-with-reference-type (各 3 件) の修正

- `src/__tests__/services/tweet-service.test.ts`: `Array.from({length:n}).fill({})` を `Array.from({length:n}, (_,i) => ({...}))` に変換

## Test Plan

- [x] `pnpm run lint` - 全エラー解消を確認
- [x] `pnpm test` - 257 passed, 20 suites 全通過
- [x] `pnpm run build` - webpack ビルド成功

Fixes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)