### PR TITLE
fix: eslint-plugin-unicorn の新ルールに対応したLintエラーを解消

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,10 @@ export default [
       'import/no-duplicates': 'off',
       camelcase: ['error', { allow: ['^GM_'] }],
       'unicorn/no-useless-undefined': 'off',
+      // テストでは globalThis / window にモック用プロパティを直接代入する場面が多いため無効化
+      'unicorn/no-global-object-property-assignment': 'off',
+      // `setXxxSpy` のような jest.spyOn 変数名は慣習的な命名のため対象外
+      'unicorn/no-non-function-verb-prefix': 'off',
     },
   },
   {
@@ -19,6 +23,8 @@ export default [
     rules: {
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
+      // モックではユーザースクリプトのグローバル API (GM_*) を直接定義する必要がある
+      'unicorn/no-global-object-property-assignment': 'off',
     },
   },
 ]

--- a/src/__tests__/core/config.test.ts
+++ b/src/__tests__/core/config.test.ts
@@ -137,8 +137,8 @@ describe('ConfigManager', () => {
      * 初期状態では全てのページで処理が有効であることを確認
      */
     it('should return false by default', () => {
-      const result = ConfigManager.getIsOnlyHome()
-      expect(result).toBe(false)
+      const isResult = ConfigManager.getIsOnlyHome()
+      expect(isResult).toBe(false)
       expect(GM_getValue).toHaveBeenCalledWith('isOnlyHome', 'false')
     })
 
@@ -149,8 +149,8 @@ describe('ConfigManager', () => {
     it('should return true when stored value is "true"', () => {
       ;(GM_getValue as jest.Mock).mockReturnValueOnce('true')
 
-      const result = ConfigManager.getIsOnlyHome()
-      expect(result).toBe(true)
+      const isResult = ConfigManager.getIsOnlyHome()
+      expect(isResult).toBe(true)
       expect(GM_getValue).toHaveBeenCalledWith('isOnlyHome', 'false')
     })
 
@@ -161,8 +161,8 @@ describe('ConfigManager', () => {
     it('should return false when stored value is "false"', () => {
       ;(GM_getValue as jest.Mock).mockReturnValueOnce('false')
 
-      const result = ConfigManager.getIsOnlyHome()
-      expect(result).toBe(false)
+      const isResult = ConfigManager.getIsOnlyHome()
+      expect(isResult).toBe(false)
     })
 
     /**
@@ -172,8 +172,8 @@ describe('ConfigManager', () => {
     it('should return false for other string values', () => {
       ;(GM_getValue as jest.Mock).mockReturnValueOnce('other')
 
-      const result = ConfigManager.getIsOnlyHome()
-      expect(result).toBe(false)
+      const isResult = ConfigManager.getIsOnlyHome()
+      expect(isResult).toBe(false)
     })
   })
 

--- a/src/__tests__/core/storage.test.ts
+++ b/src/__tests__/core/storage.test.ts
@@ -150,8 +150,8 @@ describe('Storage', () => {
      * 初期状態ではログイン通知が送信されていないことを確認
      */
     it('should return false by default', () => {
-      const result = Storage.isLoginNotified()
-      expect(result).toBe(false)
+      const isResult = Storage.isLoginNotified()
+      expect(isResult).toBe(false)
       expect(GM_getValue).toHaveBeenCalledWith('isLoginNotified', false)
     })
 
@@ -176,8 +176,8 @@ describe('Storage', () => {
      * 初期状態ではアカウントロック通知が送信されていないことを確認
      */
     it('should return false by default', () => {
-      const result = Storage.isLockedNotified()
-      expect(result).toBe(false)
+      const isResult = Storage.isLockedNotified()
+      expect(isResult).toBe(false)
       expect(GM_getValue).toHaveBeenCalledWith('isLockedNotified', false)
     })
 
@@ -228,15 +228,18 @@ describe('Storage', () => {
      * 大量データでも一定の処理時間を維持
      */
     it('should provide O(1) lookup for checked tweets', () => {
-      const testTweets = Array.from({ length: 10_000 }, (_, i) => `tweet${i}`)
+      const testTweets = Array.from(
+        { length: 10_000 },
+        (_, index) => `tweet${index}`
+      )
       Storage.setCheckedTweets(testTweets)
 
       const startTime = performance.now()
       const set = Storage.getCheckedTweetsSet()
-      const exists = set.has('tweet5000')
+      const isExists = set.has('tweet5000')
       const endTime = performance.now()
 
-      expect(exists).toBe(true)
+      expect(isExists).toBe(true)
       expect(endTime - startTime).toBeLessThan(10) // 10ms 以内
     })
 
@@ -245,15 +248,18 @@ describe('Storage', () => {
      * 線形検索からハッシュテーブル検索への改善を確認
      */
     it('should provide O(1) lookup for waiting tweets', () => {
-      const testTweets = Array.from({ length: 10_000 }, (_, i) => `waiting${i}`)
+      const testTweets = Array.from(
+        { length: 10_000 },
+        (_, index) => `waiting${index}`
+      )
       Storage.setWaitingTweets(testTweets)
 
       const startTime = performance.now()
       const set = Storage.getWaitingTweetsSet()
-      const exists = set.has('waiting7500')
+      const isExists = set.has('waiting7500')
       const endTime = performance.now()
 
-      expect(exists).toBe(true)
+      expect(isExists).toBe(true)
       expect(endTime - startTime).toBeLessThan(10) // 10ms 以内
     })
 
@@ -262,13 +268,13 @@ describe('Storage', () => {
      * 大量のツイートデータでも高速アクセスを実現
      */
     it('should provide O(1) lookup for saved tweets', () => {
-      const testTweets: Tweet[] = Array.from({ length: 1000 }, (_, i) => ({
-        url: `https://x.com/user/status/${i}`,
-        tweetText: `Test tweet ${i}`,
-        tweetHtml: `<span>Test tweet ${i}</span>`,
-        elementHtml: `<article>Element ${i}</article>`,
+      const testTweets: Tweet[] = Array.from({ length: 1000 }, (_, index) => ({
+        url: `https://x.com/user/status/${index}`,
+        tweetText: `Test tweet ${index}`,
+        tweetHtml: `<span>Test tweet ${index}</span>`,
+        elementHtml: `<article>Element ${index}</article>`,
         screenName: 'testuser',
-        tweetId: `${i}`,
+        tweetId: String(index),
         replyCount: '1',
         retweetCount: '2',
         likeCount: '3',
@@ -290,7 +296,10 @@ describe('Storage', () => {
      * 複数操作の効率的な一括処理を確認
      */
     it('should handle batch operations efficiently', () => {
-      const tweetIds = Array.from({ length: 1000 }, (_, i) => `batch${i}`)
+      const tweetIds = Array.from(
+        { length: 1000 },
+        (_, index) => `batch${index}`
+      )
 
       const startTime = performance.now()
       Storage.addCheckedTweetsBatch(tweetIds)

--- a/src/__tests__/pages/example-pages.test.ts
+++ b/src/__tests__/pages/example-pages.test.ts
@@ -4,14 +4,14 @@ import { Storage } from '../../core/storage'
 import { TweetService } from '../../services/tweet-service'
 import { QueueService } from '../../services/queue-service'
 import { NotificationService } from '../../services/notification-service'
-import { AsyncUtils } from '../../utils/async'
+import { AsyncUtilities } from '../../utils/async'
 import { TweetPage } from '../../pages/tweet-page'
 import { PageErrorHandler } from '../../utils/page-error-handler'
 import {
   setupUserscriptMocks,
   setupConsoleMocks,
   restoreConsoleMocks,
-} from '../utils/page-test-utils'
+} from '../utils/page-test-utilities'
 // Import mock before the module under test
 import { clearMockStorage } from '../../__mocks__/userscript'
 
@@ -51,7 +51,7 @@ describe('ExamplePages', () => {
     // Setup default mock implementations
     ;(TweetService.isNeedDownload as jest.Mock).mockReturnValue(false)
     ;(TweetService.downloadTweets as jest.Mock).mockImplementation(() => {})
-    ;(AsyncUtils.delay as jest.Mock).mockResolvedValue(undefined)
+    ;(AsyncUtilities.delay as jest.Mock).mockResolvedValue(undefined)
     ;(TweetPage.run as jest.Mock).mockResolvedValue(undefined)
     ;(NotificationService.notifyDiscord as jest.Mock).mockResolvedValue(
       undefined
@@ -89,7 +89,9 @@ describe('ExamplePages', () => {
       await ExamplePages.runDownloadJson()
 
       expect(TweetService.downloadTweets).not.toHaveBeenCalled()
-      expect(AsyncUtils.delay).not.toHaveBeenCalledWith(DELAYS.DOWNLOAD_WAIT)
+      expect(AsyncUtilities.delay).not.toHaveBeenCalledWith(
+        DELAYS.DOWNLOAD_WAIT
+      )
       expect(TweetPage.run).toHaveBeenCalledWith(true)
     })
 
@@ -108,7 +110,7 @@ describe('ExamplePages', () => {
         'download needed. Wait 5 seconds.'
       )
       expect(TweetService.downloadTweets).toHaveBeenCalled()
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.DOWNLOAD_WAIT)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(DELAYS.DOWNLOAD_WAIT)
       expect(TweetPage.run).toHaveBeenCalledWith(true)
     })
 
@@ -386,20 +388,20 @@ describe('ExamplePages', () => {
       expect(globalThis.alert).toHaveBeenCalledWith(
         'Successfully reset waitingTweets. Navigate to the home page in 3 seconds.'
       )
-      expect(globalThis.setTimeout).toHaveBeenCalledWith(
+      expect(setTimeout).toHaveBeenCalledWith(
         expect.any(Function),
         DELAYS.RESET_REDIRECT_WAIT
       )
 
       // Execute the setTimeout callback
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const setTimeoutCallback = (globalThis.setTimeout as any).mock.calls[0][0]
+      const setTimeoutCallback = (setTimeout as any).mock.calls[0][0]
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       setTimeoutCallback()
 
       // Since we can't mock location.href in JSDOM, we verify the behavior by checking
       // that setTimeout was called with the correct parameters
-      expect(globalThis.setTimeout).toHaveBeenCalledWith(
+      expect(setTimeout).toHaveBeenCalledWith(
         expect.any(Function),
         DELAYS.RESET_REDIRECT_WAIT
       )

--- a/src/__tests__/pages/explore-page.test.ts
+++ b/src/__tests__/pages/explore-page.test.ts
@@ -1,12 +1,12 @@
 import { ExplorePage } from '../../pages/explore-page'
 import { StateService } from '../../services/state-service'
-import { DomUtils } from '../../utils/dom'
+import { DomUtilities } from '../../utils/dom'
 import { PageErrorHandler } from '../../utils/page-error-handler'
 import {
   setupUserscriptMocks,
   setupConsoleMocks,
   restoreConsoleMocks,
-} from '../utils/page-test-utils'
+} from '../utils/page-test-utilities'
 
 // Mock dependencies
 jest.mock('../../services/state-service')
@@ -22,10 +22,10 @@ jest.useFakeTimers()
 function setupExplorePageDOM(trendCount = 3): HTMLElement[] {
   const trends: HTMLElement[] = []
 
-  for (let i = 0; i < trendCount; i++) {
+  for (let index = 0; index < trendCount; index++) {
     const trend = document.createElement('div')
     trend.dataset.testid = 'trend'
-    trend.textContent = `Trend ${i + 1}`
+    trend.textContent = `Trend ${index + 1}`
 
     const clickSpy = jest.fn()
     trend.click = clickSpy
@@ -48,7 +48,7 @@ describe('ExplorePage', () => {
 
   beforeEach(() => {
     // Reset DOM
-    document.body.innerHTML = ''
+    document.body.replaceChildren()
 
     // Setup mocks
     setupUserscriptMocks()
@@ -59,9 +59,9 @@ describe('ExplorePage', () => {
     jest.clearAllTimers()
 
     // Setup default mock implementations
-    ;(DomUtils.checkAndNavigateToLogin as jest.Mock).mockReturnValue(false)
-    ;(DomUtils.waitElement as jest.Mock).mockResolvedValue(undefined)
-    ;(DomUtils.isFailedPage as jest.Mock).mockReturnValue(false)
+    ;(DomUtilities.checkAndNavigateToLogin as jest.Mock).mockReturnValue(false)
+    ;(DomUtilities.waitElement as jest.Mock).mockResolvedValue(undefined)
+    ;(DomUtilities.isFailedPage as jest.Mock).mockReturnValue(false)
     ;(StateService.resetState as jest.Mock).mockImplementation(() => {})
     ;(PageErrorHandler.handlePageError as jest.Mock).mockResolvedValue(
       undefined
@@ -81,7 +81,7 @@ describe('ExplorePage', () => {
      * - ログインが必要な場合の早期リターン
      */
     it('should return early when login is required', async () => {
-      ;(DomUtils.checkAndNavigateToLogin as jest.Mock).mockReturnValue(true)
+      ;(DomUtilities.checkAndNavigateToLogin as jest.Mock).mockReturnValue(true)
 
       await ExplorePage.run()
 
@@ -103,7 +103,7 @@ describe('ExplorePage', () => {
       await ExplorePage.run()
 
       expect(StateService.resetState).toHaveBeenCalled()
-      expect(DomUtils.waitElement).toHaveBeenCalledWith(
+      expect(DomUtilities.waitElement).toHaveBeenCalledWith(
         'div[data-testid="trend"]'
       )
 
@@ -119,7 +119,7 @@ describe('ExplorePage', () => {
      * - エラー待機時間後のページリロード
      */
     it('should handle waitElement error and reload page', async () => {
-      ;(DomUtils.waitElement as jest.Mock).mockRejectedValue(
+      ;(DomUtilities.waitElement as jest.Mock).mockRejectedValue(
         new Error('Element not found')
       )
 
@@ -137,14 +137,14 @@ describe('ExplorePage', () => {
 
     /**
      * 失敗ページ検出時のエラーログ出力をテスト
-     * - DomUtils.isFailedPage()がtrueを返す場合
+     * - DomUtilities.isFailedPage()がtrueを返す場合
      * - 専用エラーメッセージの出力確認
      */
     it('should log error when failed page is detected', async () => {
-      ;(DomUtils.waitElement as jest.Mock).mockRejectedValue(
+      ;(DomUtilities.waitElement as jest.Mock).mockRejectedValue(
         new Error('Element not found')
       )
-      ;(DomUtils.isFailedPage as jest.Mock).mockReturnValue(true)
+      ;(DomUtilities.isFailedPage as jest.Mock).mockReturnValue(true)
 
       await ExplorePage.run()
 
@@ -223,7 +223,7 @@ describe('ExplorePage', () => {
       await expect(ExplorePage.run()).rejects.toThrow()
 
       expect(StateService.resetState).toHaveBeenCalled()
-      expect(DomUtils.waitElement).toHaveBeenCalled()
+      expect(DomUtilities.waitElement).toHaveBeenCalled()
 
       mockMathRandom.mockRestore()
     })

--- a/src/__tests__/pages/home-page.test.ts
+++ b/src/__tests__/pages/home-page.test.ts
@@ -3,15 +3,15 @@ import { DELAYS } from '../../core/constants'
 import { ConfigManager } from '../../core/config'
 import { StateService } from '../../services/state-service'
 import { CrawlerService } from '../../services/crawler-service'
-import { DomUtils } from '../../utils/dom'
-import { AsyncUtils } from '../../utils/async'
+import { DomUtilities } from '../../utils/dom'
+import { AsyncUtilities } from '../../utils/async'
 import { PageErrorHandler } from '../../utils/page-error-handler'
 import {
   setupTwitterDOM,
   setupUserscriptMocks,
   setupConsoleMocks,
   restoreConsoleMocks,
-} from '../utils/page-test-utils'
+} from '../utils/page-test-utilities'
 
 // Mock dependencies
 jest.mock('../../core/config')
@@ -36,7 +36,7 @@ describe('HomePage', () => {
 
   beforeEach(() => {
     // Reset DOM
-    document.body.innerHTML = ''
+    document.body.replaceChildren()
 
     // Setup mocks
     setupUserscriptMocks()
@@ -47,10 +47,10 @@ describe('HomePage', () => {
     jest.clearAllTimers()
 
     // Reset mock implementations
-    ;(DomUtils.checkAndNavigateToLogin as jest.Mock).mockReturnValue(false)
-    ;(DomUtils.waitElement as jest.Mock).mockResolvedValue(undefined)
-    ;(DomUtils.isFailedPage as jest.Mock).mockReturnValue(false)
-    ;(AsyncUtils.delay as jest.Mock).mockResolvedValue(undefined)
+    ;(DomUtilities.checkAndNavigateToLogin as jest.Mock).mockReturnValue(false)
+    ;(DomUtilities.waitElement as jest.Mock).mockResolvedValue(undefined)
+    ;(DomUtilities.isFailedPage as jest.Mock).mockReturnValue(false)
+    ;(AsyncUtilities.delay as jest.Mock).mockResolvedValue(undefined)
     ;(ConfigManager.getIsOnlyHome as jest.Mock).mockReturnValue(false)
     ;(StateService.resetState as jest.Mock).mockImplementation(() => {})
     ;(CrawlerService.startCrawling as jest.Mock).mockImplementation(() => {})
@@ -81,13 +81,13 @@ describe('HomePage', () => {
 
       expect(StateService.resetState).toHaveBeenCalled()
       expect(CrawlerService.startCrawling).toHaveBeenCalled()
-      expect(DomUtils.waitElement).toHaveBeenCalledWith(
+      expect(DomUtilities.waitElement).toHaveBeenCalledWith(
         'div[data-testid="primaryColumn"] nav[aria-live="polite"][role="navigation"] div[role="tablist"] > div[role="presentation"] a[role="tab"]'
       )
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.LONG * 3)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(DELAYS.LONG * 3)
       // Since we can't mock location.href in JSDOM, we verify the behavior by checking
       // that all tabs were processed
-      expect(DomUtils.waitElement).toHaveBeenCalled()
+      expect(DomUtilities.waitElement).toHaveBeenCalled()
     })
 
     /**
@@ -96,7 +96,7 @@ describe('HomePage', () => {
      * - 他の処理が実行されないことを確認
      */
     it('should return early when login is required', async () => {
-      ;(DomUtils.checkAndNavigateToLogin as jest.Mock).mockReturnValue(true)
+      ;(DomUtilities.checkAndNavigateToLogin as jest.Mock).mockReturnValue(true)
 
       await HomePage.run()
 
@@ -110,7 +110,7 @@ describe('HomePage', () => {
      * - エラー待機時間後のページリロード
      */
     it('should handle waitElement error and reload page', async () => {
-      ;(DomUtils.waitElement as jest.Mock).mockRejectedValue(
+      ;(DomUtilities.waitElement as jest.Mock).mockRejectedValue(
         new Error('Element not found')
       )
 
@@ -125,14 +125,14 @@ describe('HomePage', () => {
 
     /**
      * 失敗ページ検出時のエラーハンドリングをテスト
-     * - DomUtils.isFailedPage()がtrueを返す場合
+     * - DomUtilities.isFailedPage()がtrueを返す場合
      * - PageErrorHandler.handlePageError()の呼び出し確認
      */
     it('should handle error when failed page is detected', async () => {
-      ;(DomUtils.waitElement as jest.Mock).mockRejectedValue(
+      ;(DomUtilities.waitElement as jest.Mock).mockRejectedValue(
         new Error('Element not found')
       )
-      ;(DomUtils.isFailedPage as jest.Mock).mockReturnValue(true)
+      ;(DomUtilities.isFailedPage as jest.Mock).mockReturnValue(true)
 
       await HomePage.run()
 
@@ -168,7 +168,7 @@ describe('HomePage', () => {
       }
 
       // Verify tweet waiting was called for each tab
-      expect(DomUtils.waitElement).toHaveBeenCalledWith(
+      expect(DomUtilities.waitElement).toHaveBeenCalledWith(
         'article[data-testid="tweet"]'
       )
 
@@ -188,7 +188,7 @@ describe('HomePage', () => {
       setupTwitterDOM()
 
       // Mock waitElement to fail only for tweet elements
-      ;(DomUtils.waitElement as jest.Mock).mockImplementation(
+      ;(DomUtilities.waitElement as jest.Mock).mockImplementation(
         (selector: string) => {
           if (selector.includes('article[data-testid="tweet"]')) {
             return Promise.reject(new Error('Tweet not found'))
@@ -209,7 +209,7 @@ describe('HomePage', () => {
      */
     it('should reload when tweet waiting fails on failed page', async () => {
       setupTwitterDOM()
-      ;(DomUtils.waitElement as jest.Mock).mockImplementation(
+      ;(DomUtilities.waitElement as jest.Mock).mockImplementation(
         (selector: string) => {
           if (selector.includes('article[data-testid="tweet"]')) {
             return Promise.reject(new Error('Tweet not found'))
@@ -217,7 +217,7 @@ describe('HomePage', () => {
           return Promise.resolve()
         }
       )
-      ;(DomUtils.isFailedPage as jest.Mock).mockReturnValue(true)
+      ;(DomUtilities.isFailedPage as jest.Mock).mockReturnValue(true)
 
       await HomePage.run()
 
@@ -267,7 +267,7 @@ describe('HomePage', () => {
       })
 
       // Verify scroll delay
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
     })
 
     /**
@@ -287,8 +287,10 @@ describe('HomePage', () => {
       )
 
       // Check individual tab logs
-      for (let i = 0; i < tabs.length; i++) {
-        expect(PageErrorHandler.logAction).toHaveBeenCalledWith(`open tab=${i}`)
+      for (let index = 0; index < tabs.length; index++) {
+        expect(PageErrorHandler.logAction).toHaveBeenCalledWith(
+          `open tab=${index}`
+        )
       }
 
       expect(PageErrorHandler.logAction).toHaveBeenCalledWith(

--- a/src/__tests__/pages/other-pages.test.ts
+++ b/src/__tests__/pages/other-pages.test.ts
@@ -1,13 +1,13 @@
 import { OtherPages } from '../../pages/other-pages'
 import { URLS, DELAYS } from '../../core/constants'
 import { Storage } from '../../core/storage'
-import { AsyncUtils } from '../../utils/async'
+import { AsyncUtilities } from '../../utils/async'
 import { PageErrorHandler } from '../../utils/page-error-handler'
 import {
   setupUserscriptMocks,
   setupConsoleMocks,
   restoreConsoleMocks,
-} from '../utils/page-test-utils'
+} from '../utils/page-test-utilities'
 // Import mock before the module under test
 import { clearMockStorage } from '../../__mocks__/userscript'
 
@@ -41,24 +41,24 @@ describe('OtherPages', () => {
     jest.clearAllTimers()
 
     // Setup default mock implementations
-    ;(AsyncUtils.delay as jest.Mock).mockResolvedValue(undefined)
+    ;(AsyncUtilities.delay as jest.Mock).mockResolvedValue(undefined)
     ;(Storage.isLoginNotified as jest.Mock).mockReturnValue(false)
     ;(Storage.isLockedNotified as jest.Mock).mockReturnValue(false)
     ;(PageErrorHandler.logAction as jest.Mock).mockImplementation(() => {})
     ;(PageErrorHandler.logError as jest.Mock).mockImplementation(() => {})
 
-    // Mock history.back
-    Object.defineProperty(globalThis, 'history', {
-      value: {
-        back: jest.fn(),
+    // Mock history.back and window.open
+    Object.defineProperties(globalThis, {
+      history: {
+        value: {
+          back: jest.fn(),
+        },
+        writable: true,
       },
-      writable: true,
-    })
-
-    // Mock window.open
-    Object.defineProperty(globalThis, 'open', {
-      value: jest.fn(),
-      writable: true,
+      open: {
+        value: jest.fn(),
+        writable: true,
+      },
     })
 
     // Mock setInterval and clearInterval
@@ -153,7 +153,7 @@ describe('OtherPages', () => {
       let intervalCallback: (() => void) | undefined
 
         // Mock setInterval to capture the callback
-      ;(globalThis.setInterval as jest.Mock).mockImplementation((callback) => {
+      ;(setInterval as jest.Mock).mockImplementation((callback) => {
         intervalCallback = callback
         return 123 // Mock interval ID
       })
@@ -164,7 +164,7 @@ describe('OtherPages', () => {
       expect(PageErrorHandler.logAction).toHaveBeenCalledWith(
         'waiting for 60 seconds to process queue.'
       )
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.PROCESSING_WAIT)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(DELAYS.PROCESSING_WAIT)
 
       // Wait for the initial delay to complete
       await Promise.resolve()
@@ -172,7 +172,7 @@ describe('OtherPages', () => {
       expect(PageErrorHandler.logAction).toHaveBeenCalledWith(
         'checking for #injected-blue-block-toasts > div.toast'
       )
-      expect(globalThis.setInterval).toHaveBeenCalledWith(
+      expect(setInterval).toHaveBeenCalledWith(
         expect.any(Function),
         DELAYS.CRAWL_INTERVAL
       )
@@ -187,7 +187,7 @@ describe('OtherPages', () => {
       )
 
       // Remove toasts
-      toastContainer.innerHTML = ''
+      toastContainer.replaceChildren()
 
       // Execute interval callback again with no toasts
       if (intervalCallback) {
@@ -197,10 +197,10 @@ describe('OtherPages', () => {
       expect(PageErrorHandler.logAction).toHaveBeenCalledWith(
         'all toasts are gone.'
       )
-      expect(globalThis.clearInterval).toHaveBeenCalledWith(123)
+      expect(clearInterval).toHaveBeenCalledWith(123)
       // Since we can't mock location.href in JSDOM, we verify the behavior by checking
       // that the interval was cleared
-      expect(globalThis.clearInterval).toHaveBeenCalled()
+      expect(clearInterval).toHaveBeenCalled()
 
       await promise
     })
@@ -216,7 +216,7 @@ describe('OtherPages', () => {
       document.body.append(toastContainer)
 
       let intervalCallback: (() => void) | undefined
-      ;(globalThis.setInterval as jest.Mock).mockImplementation((callback) => {
+      ;(setInterval as jest.Mock).mockImplementation((callback) => {
         intervalCallback = callback
         return 456
       })
@@ -234,10 +234,10 @@ describe('OtherPages', () => {
       expect(PageErrorHandler.logAction).toHaveBeenCalledWith(
         'all toasts are gone.'
       )
-      expect(globalThis.clearInterval).toHaveBeenCalledWith(456)
+      expect(clearInterval).toHaveBeenCalledWith(456)
       // Since we can't mock location.href in JSDOM, we verify the behavior by checking
       // that the interval was cleared
-      expect(globalThis.clearInterval).toHaveBeenCalled()
+      expect(clearInterval).toHaveBeenCalled()
 
       await promise
     })
@@ -251,7 +251,7 @@ describe('OtherPages', () => {
       toastContainer.id = 'injected-blue-block-toasts'
 
       // Start with 3 toasts
-      for (let i = 0; i < 3; i++) {
+      for (let index = 0; index < 3; index++) {
         const toast = document.createElement('div')
         toast.className = 'toast'
         toastContainer.append(toast)
@@ -260,7 +260,7 @@ describe('OtherPages', () => {
       document.body.append(toastContainer)
 
       let intervalCallback: (() => void) | undefined
-      ;(globalThis.setInterval as jest.Mock).mockImplementation((callback) => {
+      ;(setInterval as jest.Mock).mockImplementation((callback) => {
         intervalCallback = callback
         return 789
       })
@@ -329,14 +329,14 @@ describe('OtherPages', () => {
      */
     it('should start periodic check with proper interval and incrementing count', () => {
       let intervalCallback: (() => void) | undefined
-      ;(globalThis.setInterval as jest.Mock).mockImplementation((callback) => {
+      ;(setInterval as jest.Mock).mockImplementation((callback) => {
         intervalCallback = callback
         return 555
       })
 
       OtherPages.startPeriodicUnlockCheck()
 
-      expect(globalThis.setInterval).toHaveBeenCalledWith(
+      expect(setInterval).toHaveBeenCalledWith(
         expect.any(Function),
         DELAYS.LOCKED_CHECK_INTERVAL
       )

--- a/src/__tests__/pages/search-page.test.ts
+++ b/src/__tests__/pages/search-page.test.ts
@@ -2,8 +2,8 @@ import { SearchPage } from '../../pages/search-page'
 import { DELAYS } from '../../core/constants'
 import { StateService } from '../../services/state-service'
 import { CrawlerService } from '../../services/crawler-service'
-import { DomUtils } from '../../utils/dom'
-import { AsyncUtils } from '../../utils/async'
+import { DomUtilities } from '../../utils/dom'
+import { AsyncUtilities } from '../../utils/async'
 import { TweetPage } from '../../pages/tweet-page'
 import { PageErrorHandler } from '../../utils/page-error-handler'
 import {
@@ -11,7 +11,7 @@ import {
   setupUserscriptMocks,
   setupConsoleMocks,
   restoreConsoleMocks,
-} from '../utils/page-test-utils'
+} from '../utils/page-test-utilities'
 
 // Mock dependencies
 jest.mock('../../services/state-service')
@@ -36,7 +36,7 @@ describe('SearchPage', () => {
 
   beforeEach(() => {
     // Reset DOM
-    document.body.innerHTML = ''
+    document.body.replaceChildren()
 
     // Setup mocks
     setupUserscriptMocks()
@@ -47,10 +47,10 @@ describe('SearchPage', () => {
     jest.clearAllTimers()
 
     // Setup default mock implementations
-    ;(DomUtils.checkAndNavigateToLogin as jest.Mock).mockReturnValue(false)
-    ;(DomUtils.waitElement as jest.Mock).mockResolvedValue(undefined)
-    ;(DomUtils.isFailedPage as jest.Mock).mockReturnValue(false)
-    ;(AsyncUtils.delay as jest.Mock).mockResolvedValue(undefined)
+    ;(DomUtilities.checkAndNavigateToLogin as jest.Mock).mockReturnValue(false)
+    ;(DomUtilities.waitElement as jest.Mock).mockResolvedValue(undefined)
+    ;(DomUtilities.isFailedPage as jest.Mock).mockReturnValue(false)
+    ;(AsyncUtilities.delay as jest.Mock).mockResolvedValue(undefined)
     ;(StateService.resetState as jest.Mock).mockImplementation(() => {})
     ;(CrawlerService.startCrawling as jest.Mock).mockImplementation(() => {})
     ;(TweetPage.run as jest.Mock).mockResolvedValue(undefined)
@@ -72,7 +72,7 @@ describe('SearchPage', () => {
      * - ログインが必要な場合の早期リターン
      */
     it('should return early when login is required', async () => {
-      ;(DomUtils.checkAndNavigateToLogin as jest.Mock).mockReturnValue(true)
+      ;(DomUtilities.checkAndNavigateToLogin as jest.Mock).mockReturnValue(true)
 
       await SearchPage.run()
 
@@ -96,7 +96,7 @@ describe('SearchPage', () => {
 
       await SearchPage.run()
 
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
       // Since JSDOM doesn't allow location.search assignment, we can't test the actual change
       // Instead, we verify the behavior by checking that delay was called
 
@@ -126,7 +126,7 @@ describe('SearchPage', () => {
 
       expect(StateService.resetState).toHaveBeenCalled()
       expect(CrawlerService.startCrawling).toHaveBeenCalled()
-      expect(DomUtils.waitElement).toHaveBeenCalledWith(
+      expect(DomUtilities.waitElement).toHaveBeenCalledWith(
         'article[data-testid="tweet"]'
       )
       expect(TweetPage.run).toHaveBeenCalledWith(true)
@@ -150,14 +150,16 @@ describe('SearchPage', () => {
         search: '?q=test&f=live',
         reload: jest.fn(),
       }
-      ;(DomUtils.waitElement as jest.Mock).mockRejectedValue(
+      ;(DomUtilities.waitElement as jest.Mock).mockRejectedValue(
         new Error('Element not found')
       )
 
       await SearchPage.run()
 
       expect(consoleMocks.log).toHaveBeenCalledWith('Wait 1 minute and reload.')
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.ERROR_RELOAD_WAIT)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(
+        DELAYS.ERROR_RELOAD_WAIT
+      )
       expect(globalThis.location.reload).toHaveBeenCalled()
 
       // Restore original location
@@ -167,7 +169,7 @@ describe('SearchPage', () => {
 
     /**
      * 失敗ページ検出時のエラーログ出力をテスト
-     * - DomUtils.isFailedPage()がtrueを返す場合
+     * - DomUtilities.isFailedPage()がtrueを返す場合
      * - 専用エラーメッセージの出力確認
      */
     it.skip('should log error when failed page is detected', async () => {
@@ -178,10 +180,10 @@ describe('SearchPage', () => {
       ;(globalThis as any).location = {
         search: '?q=test&f=live',
       }
-      ;(DomUtils.waitElement as jest.Mock).mockRejectedValue(
+      ;(DomUtilities.waitElement as jest.Mock).mockRejectedValue(
         new Error('Element not found')
       )
-      ;(DomUtils.isFailedPage as jest.Mock).mockReturnValue(true)
+      ;(DomUtilities.isFailedPage as jest.Mock).mockReturnValue(true)
 
       await SearchPage.run()
 
@@ -220,7 +222,7 @@ describe('SearchPage', () => {
       })
 
       // Verify delay was called for each scroll
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
 
       // Restore original location
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -273,7 +275,7 @@ describe('SearchPage', () => {
 
       await SearchPage.run()
 
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
       // We verify the behavior by checking that delay was called, not the actual location change
 
       // Restore original location
@@ -297,7 +299,7 @@ describe('SearchPage', () => {
 
       await SearchPage.run()
 
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(DELAYS.CRAWL_INTERVAL)
       // We verify the behavior by checking that delay was called
 
       // Restore original location

--- a/src/__tests__/pages/tweet-page.test.ts
+++ b/src/__tests__/pages/tweet-page.test.ts
@@ -5,16 +5,16 @@ import { StateService } from '../../services/state-service'
 import { CrawlerService } from '../../services/crawler-service'
 import { QueueService } from '../../services/queue-service'
 import { TweetService } from '../../services/tweet-service'
-import { DomUtils } from '../../utils/dom'
-import { ScrollUtils } from '../../utils/scroll'
+import { DomUtilities } from '../../utils/dom'
+import { ScrollUtilities } from '../../utils/scroll'
 import { PageErrorHandler } from '../../utils/page-error-handler'
-import { AsyncUtils } from '../../utils/async'
+import { AsyncUtilities } from '../../utils/async'
 import {
   setupTweetPageDOM,
   setupUserscriptMocks,
   setupConsoleMocks,
   restoreConsoleMocks,
-} from '../utils/page-test-utils'
+} from '../utils/page-test-utilities'
 
 // Mock dependencies
 jest.mock('../../core/storage')
@@ -42,7 +42,7 @@ describe('TweetPage', () => {
 
   beforeEach(() => {
     // Reset DOM
-    document.body.innerHTML = ''
+    document.body.replaceChildren()
 
     // Setup mocks
     setupUserscriptMocks()
@@ -53,10 +53,10 @@ describe('TweetPage', () => {
     jest.clearAllTimers()
 
     // Setup default mock implementations
-    ;(DomUtils.checkAndNavigateToLogin as jest.Mock).mockReturnValue(false)
-    ;(DomUtils.waitElement as jest.Mock).mockResolvedValue(undefined)
-    ;(DomUtils.isFailedPage as jest.Mock).mockReturnValue(false)
-    ;(AsyncUtils.delay as jest.Mock).mockResolvedValue(undefined)
+    ;(DomUtilities.checkAndNavigateToLogin as jest.Mock).mockReturnValue(false)
+    ;(DomUtilities.waitElement as jest.Mock).mockResolvedValue(undefined)
+    ;(DomUtilities.isFailedPage as jest.Mock).mockReturnValue(false)
+    ;(AsyncUtilities.delay as jest.Mock).mockResolvedValue(undefined)
     ;(StateService.resetState as jest.Mock).mockImplementation(() => {})
     ;(CrawlerService.startCrawling as jest.Mock).mockImplementation(() => {})
     ;(CrawlerService.getCrawledTweetCount as jest.Mock).mockReturnValue(1)
@@ -70,7 +70,7 @@ describe('TweetPage', () => {
     ;(QueueService.checkedTweet as jest.Mock).mockResolvedValue(undefined)
     ;(Storage.getRetryCount as jest.Mock).mockReturnValue(0)
     ;(Storage.setRetryCount as jest.Mock).mockImplementation(() => {})
-    ;(ScrollUtils.scrollPage as jest.Mock).mockResolvedValue(undefined)
+    ;(ScrollUtilities.scrollPage as jest.Mock).mockResolvedValue(undefined)
     ;(PageErrorHandler.logAction as jest.Mock).mockImplementation(() => {})
     ;(PageErrorHandler.logError as jest.Mock).mockImplementation(() => {})
     ;(PageErrorHandler.handlePageError as jest.Mock).mockResolvedValue(
@@ -89,7 +89,7 @@ describe('TweetPage', () => {
      * - ログインが必要な場合の早期リターン
      */
     it('should return early when login is required', async () => {
-      ;(DomUtils.checkAndNavigateToLogin as jest.Mock).mockReturnValue(true)
+      ;(DomUtilities.checkAndNavigateToLogin as jest.Mock).mockReturnValue(true)
 
       await TweetPage.run()
 
@@ -153,7 +153,7 @@ describe('TweetPage', () => {
      */
     it('should process tweet page successfully', async () => {
       setupTweetPageDOM()
-      globalThis.location.href = 'https://x.com/user/status/123456789'
+      globalThis.location.assign('https://x.com/user/status/123456789')
 
       // Mock regex match
       jest
@@ -168,10 +168,10 @@ describe('TweetPage', () => {
 
       expect(StateService.resetState).toHaveBeenCalled()
       expect(CrawlerService.startCrawling).toHaveBeenCalled()
-      expect(DomUtils.waitElement).toHaveBeenCalledWith(
+      expect(DomUtilities.waitElement).toHaveBeenCalledWith(
         'article[data-testid="tweet"]'
       )
-      expect(ScrollUtils.scrollPage).toHaveBeenCalled()
+      expect(ScrollUtilities.scrollPage).toHaveBeenCalled()
       expect(QueueService.checkedTweet).toHaveBeenCalledWith('123456789')
     })
 
@@ -182,7 +182,7 @@ describe('TweetPage', () => {
      * - 待機後のページリロード
      */
     it('should retry when tweet element is not found', async () => {
-      ;(DomUtils.waitElement as jest.Mock).mockRejectedValue(
+      ;(DomUtilities.waitElement as jest.Mock).mockRejectedValue(
         new Error('Element not found')
       )
       ;(Storage.getRetryCount as jest.Mock).mockReturnValue(1)
@@ -198,7 +198,7 @@ describe('TweetPage', () => {
         }
       )
       expect(Storage.setRetryCount).toHaveBeenCalledWith(2)
-      // AsyncUtils.delay is called within PageErrorHandler.handlePageError,
+      // AsyncUtilities.delay is called within PageErrorHandler.handlePageError,
       // so we don't need to verify it separately
     })
 
@@ -210,13 +210,13 @@ describe('TweetPage', () => {
      * - 次ツイートへの遷移
      */
     it('should skip tweet after max retries', async () => {
-      ;(DomUtils.waitElement as jest.Mock).mockRejectedValue(
+      ;(DomUtilities.waitElement as jest.Mock).mockRejectedValue(
         new Error('Element not found')
       )
       ;(Storage.getRetryCount as jest.Mock).mockReturnValue(
         THRESHOLDS.MAX_RETRY_COUNT
       )
-      globalThis.location.href = 'https://x.com/user/status/987654321'
+      globalThis.location.assign('https://x.com/user/status/987654321')
 
       // Mock regex match
       jest
@@ -238,14 +238,14 @@ describe('TweetPage', () => {
 
     /**
      * 失敗ページ検出時のエラーログ出力をテスト
-     * - DomUtils.isFailedPage()がtrueを返す場合
+     * - DomUtilities.isFailedPage()がtrueを返す場合
      * - 専用エラーメッセージの出力確認
      */
     it('should log error when failed page is detected', async () => {
-      ;(DomUtils.waitElement as jest.Mock).mockRejectedValue(
+      ;(DomUtilities.waitElement as jest.Mock).mockRejectedValue(
         new Error('Element not found')
       )
-      ;(DomUtils.isFailedPage as jest.Mock).mockReturnValue(true)
+      ;(DomUtilities.isFailedPage as jest.Mock).mockReturnValue(true)
 
       await TweetPage.run()
 
@@ -281,7 +281,7 @@ describe('TweetPage', () => {
      * - クロール数のリセット
      */
     it('should handle error dialog callback for deleted tweet', async () => {
-      globalThis.location.href = 'https://x.com/user/status/111222333'
+      globalThis.location.assign('https://x.com/user/status/111222333')
 
       // Mock regex match
       jest
@@ -309,7 +309,7 @@ describe('TweetPage', () => {
      * - クロール数のリセット
      */
     it('should handle unprocessable post detection callback', async () => {
-      globalThis.location.href = 'https://x.com/user/status/444555666'
+      globalThis.location.assign('https://x.com/user/status/444555666')
 
       // Mock regex match
       jest
@@ -337,7 +337,7 @@ describe('TweetPage', () => {
      */
     it('should reset retry count on successful processing', async () => {
       setupTweetPageDOM()
-      globalThis.location.href = 'https://x.com/user/status/777888999'
+      globalThis.location.assign('https://x.com/user/status/777888999')
 
       // Mock regex match
       jest
@@ -359,7 +359,7 @@ describe('TweetPage', () => {
      * - 適切な削除処理の実行
      */
     it('should handle English deleted tweet message', async () => {
-      globalThis.location.href = 'https://x.com/user/status/555666777'
+      globalThis.location.assign('https://x.com/user/status/555666777')
 
       // Mock regex match
       jest

--- a/src/__tests__/services/queue-service.test.ts
+++ b/src/__tests__/services/queue-service.test.ts
@@ -42,8 +42,8 @@ describe('QueueService', () => {
         .spyOn(Storage, 'getCheckedTweets')
         .mockReturnValue(['tweet1', 'tweet2'])
 
-      const result = QueueService.isCheckedTweet('tweet1')
-      expect(result).toBe(true)
+      const isResult = QueueService.isCheckedTweet('tweet1')
+      expect(isResult).toBe(true)
     })
 
     /**
@@ -55,8 +55,8 @@ describe('QueueService', () => {
         .spyOn(Storage, 'getCheckedTweets')
         .mockReturnValue(['tweet1', 'tweet2'])
 
-      const result = QueueService.isCheckedTweet('tweet3')
-      expect(result).toBe(false)
+      const isResult = QueueService.isCheckedTweet('tweet3')
+      expect(isResult).toBe(false)
     })
 
     /**
@@ -66,8 +66,8 @@ describe('QueueService', () => {
     it('should return false for empty checked tweets list', () => {
       jest.spyOn(Storage, 'getCheckedTweets').mockReturnValue([])
 
-      const result = QueueService.isCheckedTweet('tweet1')
-      expect(result).toBe(false)
+      const isResult = QueueService.isCheckedTweet('tweet1')
+      expect(isResult).toBe(false)
     })
   })
 
@@ -87,8 +87,8 @@ describe('QueueService', () => {
         .spyOn(Storage, 'getWaitingTweets')
         .mockReturnValue(['waiting1', 'waiting2'])
 
-      const result = QueueService.isWaitingTweet('waiting1')
-      expect(result).toBe(true)
+      const isResult = QueueService.isWaitingTweet('waiting1')
+      expect(isResult).toBe(true)
     })
 
     /**
@@ -100,8 +100,8 @@ describe('QueueService', () => {
         .spyOn(Storage, 'getWaitingTweets')
         .mockReturnValue(['waiting1', 'waiting2'])
 
-      const result = QueueService.isWaitingTweet('waiting3')
-      expect(result).toBe(false)
+      const isResult = QueueService.isWaitingTweet('waiting3')
+      expect(isResult).toBe(false)
     })
 
     /**
@@ -111,8 +111,8 @@ describe('QueueService', () => {
     it('should return false for empty waiting tweets list', () => {
       jest.spyOn(Storage, 'getWaitingTweets').mockReturnValue([])
 
-      const result = QueueService.isWaitingTweet('waiting1')
-      expect(result).toBe(false)
+      const isResult = QueueService.isWaitingTweet('waiting1')
+      expect(isResult).toBe(false)
     })
   })
 
@@ -132,13 +132,13 @@ describe('QueueService', () => {
     it('should add tweets to waiting list', async () => {
       const existingTweets = ['existing1', 'existing2']
       const newTweets = ['new1', 'new2']
-      const setWaitingTweetsSpy = jest.spyOn(Storage, 'setWaitingTweets')
+      const waitingTweetsSetSpy = jest.spyOn(Storage, 'setWaitingTweets')
 
       jest.spyOn(Storage, 'getWaitingTweets').mockReturnValue(existingTweets)
 
       const promise = QueueService.addWaitingTweets(newTweets)
 
-      expect(setWaitingTweetsSpy).toHaveBeenCalledWith([
+      expect(waitingTweetsSetSpy).toHaveBeenCalledWith([
         'existing1',
         'existing2',
         'new1',
@@ -157,13 +157,13 @@ describe('QueueService', () => {
      */
     it('should handle empty new tweets array', async () => {
       const existingTweets = ['existing1']
-      const setWaitingTweetsSpy = jest.spyOn(Storage, 'setWaitingTweets')
+      const waitingTweetsSetSpy = jest.spyOn(Storage, 'setWaitingTweets')
 
       jest.spyOn(Storage, 'getWaitingTweets').mockReturnValue(existingTweets)
 
       const promise = QueueService.addWaitingTweets([])
 
-      expect(setWaitingTweetsSpy).toHaveBeenCalledWith(['existing1'])
+      expect(waitingTweetsSetSpy).toHaveBeenCalledWith(['existing1'])
 
       jest.advanceTimersByTime(1000)
       await promise
@@ -223,8 +223,8 @@ describe('QueueService', () => {
       const existingChecked = ['checked1']
       const existingWaiting = ['test123', 'waiting2']
 
-      const setCheckedTweetsSpy = jest.spyOn(Storage, 'setCheckedTweets')
-      const setWaitingTweetsSpy = jest.spyOn(Storage, 'setWaitingTweets')
+      const checkedTweetsSetSpy = jest.spyOn(Storage, 'setCheckedTweets')
+      const waitingTweetsSetSpy = jest.spyOn(Storage, 'setWaitingTweets')
 
       jest.spyOn(Storage, 'getCheckedTweets').mockReturnValue(existingChecked)
       jest.spyOn(Storage, 'getWaitingTweets').mockReturnValue(existingWaiting)
@@ -233,8 +233,8 @@ describe('QueueService', () => {
 
       const promise = QueueService.checkedTweet(tweetId)
 
-      expect(setCheckedTweetsSpy).toHaveBeenCalledWith(['checked1', 'test123'])
-      expect(setWaitingTweetsSpy).toHaveBeenCalledWith(['waiting2'])
+      expect(checkedTweetsSetSpy).toHaveBeenCalledWith(['checked1', 'test123'])
+      expect(waitingTweetsSetSpy).toHaveBeenCalledWith(['waiting2'])
       expect(consoleSpy).toHaveBeenCalledWith('checkedTweet: test123')
 
       jest.advanceTimersByTime(1000)
@@ -254,20 +254,20 @@ describe('QueueService', () => {
       const existingChecked = ['checked1']
       const existingWaiting = ['waiting1', 'waiting2']
 
-      const setCheckedTweetsSpy = jest.spyOn(Storage, 'setCheckedTweets')
-      const setWaitingTweetsSpy = jest.spyOn(Storage, 'setWaitingTweets')
+      const checkedTweetsSetSpy = jest.spyOn(Storage, 'setCheckedTweets')
+      const waitingTweetsSetSpy = jest.spyOn(Storage, 'setWaitingTweets')
 
       jest.spyOn(Storage, 'getCheckedTweets').mockReturnValue(existingChecked)
       jest.spyOn(Storage, 'getWaitingTweets').mockReturnValue(existingWaiting)
 
       const promise = QueueService.checkedTweet(tweetId)
 
-      expect(setCheckedTweetsSpy).toHaveBeenCalledWith([
+      expect(checkedTweetsSetSpy).toHaveBeenCalledWith([
         'checked1',
         'notInWaiting',
       ])
       // When tweet is not in waiting list, setWaitingTweets should not be called
-      expect(setWaitingTweetsSpy).not.toHaveBeenCalled()
+      expect(waitingTweetsSetSpy).not.toHaveBeenCalled()
 
       jest.advanceTimersByTime(1000)
       await promise
@@ -286,11 +286,11 @@ describe('QueueService', () => {
      * - ストレージ更新の適切な呼び出し確認
      */
     it('should clear waiting tweets list', () => {
-      const setWaitingTweetsSpy = jest.spyOn(Storage, 'setWaitingTweets')
+      const waitingTweetsSetSpy = jest.spyOn(Storage, 'setWaitingTweets')
 
       QueueService.resetWaitingQueue()
 
-      expect(setWaitingTweetsSpy).toHaveBeenCalledWith([])
+      expect(waitingTweetsSetSpy).toHaveBeenCalledWith([])
     })
   })
 })

--- a/src/__tests__/services/state-service.test.ts
+++ b/src/__tests__/services/state-service.test.ts
@@ -46,20 +46,20 @@ describe('StateService', () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
       jest.spyOn(Storage, 'isLoginNotified').mockReturnValue(true)
       jest.spyOn(Storage, 'isLockedNotified').mockReturnValue(false)
-      const setLoginNotifiedSpy = jest.spyOn(Storage, 'setLoginNotified')
-      const setLockedNotifiedSpy = jest.spyOn(Storage, 'setLockedNotified')
+      const loginNotifiedSetSpy = jest.spyOn(Storage, 'setLoginNotified')
+      const lockedNotifiedSetSpy = jest.spyOn(Storage, 'setLockedNotified')
 
       StateService.resetState()
 
       expect(consoleSpy).toHaveBeenCalledWith(
         'resetState: reset isLoginNotified'
       )
-      expect(setLoginNotifiedSpy).toHaveBeenCalledWith(false)
+      expect(loginNotifiedSetSpy).toHaveBeenCalledWith(false)
       expect(mockWindowOpen).toHaveBeenCalledWith(
         URLS.EXAMPLE_LOGIN_SUCCESS_NOTIFY,
         '_blank'
       )
-      expect(setLockedNotifiedSpy).not.toHaveBeenCalled()
+      expect(lockedNotifiedSetSpy).not.toHaveBeenCalled()
 
       consoleSpy.mockRestore()
     })
@@ -75,20 +75,20 @@ describe('StateService', () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
       jest.spyOn(Storage, 'isLoginNotified').mockReturnValue(false)
       jest.spyOn(Storage, 'isLockedNotified').mockReturnValue(true)
-      const setLoginNotifiedSpy = jest.spyOn(Storage, 'setLoginNotified')
-      const setLockedNotifiedSpy = jest.spyOn(Storage, 'setLockedNotified')
+      const loginNotifiedSetSpy = jest.spyOn(Storage, 'setLoginNotified')
+      const lockedNotifiedSetSpy = jest.spyOn(Storage, 'setLockedNotified')
 
       StateService.resetState()
 
       expect(consoleSpy).toHaveBeenCalledWith(
         'resetState: reset isLockedNotified'
       )
-      expect(setLockedNotifiedSpy).toHaveBeenCalledWith(false)
+      expect(lockedNotifiedSetSpy).toHaveBeenCalledWith(false)
       expect(mockWindowOpen).toHaveBeenCalledWith(
         URLS.EXAMPLE_UNLOCKED_NOTIFY,
         '_blank'
       )
-      expect(setLoginNotifiedSpy).not.toHaveBeenCalled()
+      expect(loginNotifiedSetSpy).not.toHaveBeenCalled()
 
       consoleSpy.mockRestore()
     })
@@ -104,8 +104,8 @@ describe('StateService', () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
       jest.spyOn(Storage, 'isLoginNotified').mockReturnValue(true)
       jest.spyOn(Storage, 'isLockedNotified').mockReturnValue(true)
-      const setLoginNotifiedSpy = jest.spyOn(Storage, 'setLoginNotified')
-      const setLockedNotifiedSpy = jest.spyOn(Storage, 'setLockedNotified')
+      const loginNotifiedSetSpy = jest.spyOn(Storage, 'setLoginNotified')
+      const lockedNotifiedSetSpy = jest.spyOn(Storage, 'setLockedNotified')
 
       StateService.resetState()
 
@@ -115,8 +115,8 @@ describe('StateService', () => {
       expect(consoleSpy).toHaveBeenCalledWith(
         'resetState: reset isLockedNotified'
       )
-      expect(setLoginNotifiedSpy).toHaveBeenCalledWith(false)
-      expect(setLockedNotifiedSpy).toHaveBeenCalledWith(false)
+      expect(loginNotifiedSetSpy).toHaveBeenCalledWith(false)
+      expect(lockedNotifiedSetSpy).toHaveBeenCalledWith(false)
       expect(mockWindowOpen).toHaveBeenCalledWith(
         URLS.EXAMPLE_LOGIN_SUCCESS_NOTIFY,
         '_blank'
@@ -140,14 +140,14 @@ describe('StateService', () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
       jest.spyOn(Storage, 'isLoginNotified').mockReturnValue(false)
       jest.spyOn(Storage, 'isLockedNotified').mockReturnValue(false)
-      const setLoginNotifiedSpy = jest.spyOn(Storage, 'setLoginNotified')
-      const setLockedNotifiedSpy = jest.spyOn(Storage, 'setLockedNotified')
+      const loginNotifiedSetSpy = jest.spyOn(Storage, 'setLoginNotified')
+      const lockedNotifiedSetSpy = jest.spyOn(Storage, 'setLockedNotified')
 
       StateService.resetState()
 
       expect(consoleSpy).not.toHaveBeenCalled()
-      expect(setLoginNotifiedSpy).not.toHaveBeenCalled()
-      expect(setLockedNotifiedSpy).not.toHaveBeenCalled()
+      expect(loginNotifiedSetSpy).not.toHaveBeenCalled()
+      expect(lockedNotifiedSetSpy).not.toHaveBeenCalled()
       expect(mockWindowOpen).not.toHaveBeenCalled()
 
       consoleSpy.mockRestore()

--- a/src/__tests__/services/tweet-service.test.ts
+++ b/src/__tests__/services/tweet-service.test.ts
@@ -16,8 +16,8 @@ const originalCreateElement = document.createElement.bind(document)
 const originalAppend = document.body.append.bind(document.body)
 
 // Mock URL.createObjectURL and URL.revokeObjectURL
-globalThis.URL.createObjectURL = jest.fn(() => 'mock-blob-url')
-globalThis.URL.revokeObjectURL = jest.fn()
+URL.createObjectURL = jest.fn(() => 'mock-blob-url')
+URL.revokeObjectURL = jest.fn()
 
 // Mock Blob
 globalThis.Blob = jest.fn().mockImplementation((data, options) => ({
@@ -36,7 +36,7 @@ globalThis.Blob = jest.fn().mockImplementation((data, options) => ({
  */
 describe('TweetService', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''
+    document.body.replaceChildren()
     jest.clearAllMocks()
     mockCreateElement.mockClear()
     mockAppend.mockClear()
@@ -390,9 +390,9 @@ describe('TweetService', () => {
 
       ;(Storage.getSavedTweets as jest.Mock).mockReturnValue(tweets)
 
-      const result = TweetService.isNeedDownload()
+      const isResult = TweetService.isNeedDownload()
 
-      expect(result).toBe(true)
+      expect(isResult).toBe(true)
     })
 
     /**
@@ -410,9 +410,9 @@ describe('TweetService', () => {
 
       ;(Storage.getSavedTweets as jest.Mock).mockReturnValue(tweets)
 
-      const result = TweetService.isNeedDownload()
+      const isResult = TweetService.isNeedDownload()
 
-      expect(result).toBe(false)
+      expect(isResult).toBe(false)
     })
 
     /**
@@ -430,9 +430,9 @@ describe('TweetService', () => {
 
       ;(Storage.getSavedTweets as jest.Mock).mockReturnValue(tweets)
 
-      const result = TweetService.isNeedDownload()
+      const isResult = TweetService.isNeedDownload()
 
-      expect(result).toBe(false)
+      expect(isResult).toBe(false)
     })
   })
 
@@ -483,10 +483,10 @@ describe('TweetService', () => {
 
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
-      const result = TweetService.downloadTweets()
+      const isResult = TweetService.downloadTweets()
 
       expect(consoleSpy).toHaveBeenCalledWith('downloadTweets: download tweets')
-      expect(globalThis.Blob).toHaveBeenCalledWith(
+      expect(Blob).toHaveBeenCalledWith(
         [
           JSON.stringify({
             type: 'tweets',
@@ -495,7 +495,7 @@ describe('TweetService', () => {
         ],
         { type: 'application/json' }
       )
-      expect(globalThis.URL.createObjectURL).toHaveBeenCalled()
+      expect(URL.createObjectURL).toHaveBeenCalled()
       expect(mockAnchor.href).toBe('mock-blob-url')
       expect(mockAnchor.download).toMatch(
         /^tweets-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z\.json$/
@@ -504,7 +504,7 @@ describe('TweetService', () => {
       expect(mockAppend).toHaveBeenCalledWith(mockAnchor)
       expect(mockClick).toHaveBeenCalled()
       expect(Storage.setSavedTweets).toHaveBeenCalledWith([])
-      expect(result).toBe(true)
+      expect(isResult).toBe(true)
 
       consoleSpy.mockRestore()
     })
@@ -689,9 +689,9 @@ describe('TweetService', () => {
 
       // Mock querySelector to count calls
       // eslint-disable-next-line @typescript-eslint/no-deprecated
-      article.querySelector = jest.fn((...args) => {
+      article.querySelector = jest.fn((...arguments_) => {
         queryCount++
-        return originalQuerySelector(...args)
+        return originalQuerySelector(...arguments_)
       })
 
       article.dataset.testid = 'tweet'
@@ -760,13 +760,13 @@ describe('TweetService', () => {
     it('should process large number of tweets efficiently', () => {
       // Create 100 mock tweet articles
       const articles: Element[] = []
-      for (let i = 0; i < 100; i++) {
+      for (let index = 0; index < 100; index++) {
         const article = document.createElement('article')
         article.dataset.testid = 'tweet'
 
         const link = document.createElement('a')
         link.setAttribute('role', 'link')
-        link.href = `https://x.com/user${i}/status/${i}`
+        link.href = `https://x.com/user${index}/status/${index}`
         const time = document.createElement('time')
         time.setAttribute('datetime', '2024-01-01T12:00:00Z')
         link.append(time)
@@ -775,22 +775,22 @@ describe('TweetService', () => {
         textDiv.setAttribute('lang', 'ja')
         textDiv.setAttribute('dir', 'ltr')
         textDiv.dataset.testid = 'tweetText'
-        textDiv.textContent = `Tweet content ${i}`
+        textDiv.textContent = `Tweet content ${index}`
 
         const replyButton = document.createElement('button')
         replyButton.setAttribute('role', 'button')
         replyButton.dataset.testid = 'reply'
-        replyButton.setAttribute('aria-label', `${i} replies`)
+        replyButton.setAttribute('aria-label', `${index} replies`)
 
         const retweetButton = document.createElement('button')
         retweetButton.setAttribute('role', 'button')
         retweetButton.dataset.testid = 'retweet'
-        retweetButton.setAttribute('aria-label', `${i * 2} retweets`)
+        retweetButton.setAttribute('aria-label', `${index * 2} retweets`)
 
         const likeButton = document.createElement('button')
         likeButton.setAttribute('role', 'button')
         likeButton.dataset.testid = 'like'
-        likeButton.setAttribute('aria-label', `${i * 3} likes`)
+        likeButton.setAttribute('aria-label', `${index * 3} likes`)
 
         article.append(link, textDiv, replyButton, retweetButton, likeButton)
         articles.push(article)
@@ -825,9 +825,9 @@ describe('TweetService', () => {
 
       // Mock querySelector to count calls
       // eslint-disable-next-line @typescript-eslint/no-deprecated
-      article.querySelector = jest.fn((...args) => {
+      article.querySelector = jest.fn((...arguments_) => {
         queryCount++
-        return originalQuerySelector(...args)
+        return originalQuerySelector(...arguments_)
       })
 
       article.dataset.testid = 'tweet'

--- a/src/__tests__/services/version-service.test.ts
+++ b/src/__tests__/services/version-service.test.ts
@@ -27,7 +27,7 @@ describe('VersionService', () => {
     it('should store version without notification on first run', () => {
       // Arrange
       jest.spyOn(Storage, 'getStoredVersion').mockReturnValue('')
-      const setStoredVersionSpy = jest
+      const storedVersionSetSpy = jest
         .spyOn(Storage, 'setStoredVersion')
         .mockImplementation()
       const notifyVersionUpdateSpy = jest
@@ -38,14 +38,14 @@ describe('VersionService', () => {
       VersionService.checkVersionAndNotify('1.0.0')
 
       // Assert
-      expect(setStoredVersionSpy).toHaveBeenCalledWith('1.0.0')
+      expect(storedVersionSetSpy).toHaveBeenCalledWith('1.0.0')
       expect(notifyVersionUpdateSpy).not.toHaveBeenCalled()
     })
 
     it('should do nothing when version is unchanged', () => {
       // Arrange
       jest.spyOn(Storage, 'getStoredVersion').mockReturnValue('1.0.0')
-      const setStoredVersionSpy = jest
+      const storedVersionSetSpy = jest
         .spyOn(Storage, 'setStoredVersion')
         .mockImplementation()
       const notifyVersionUpdateSpy = jest
@@ -56,14 +56,14 @@ describe('VersionService', () => {
       VersionService.checkVersionAndNotify('1.0.0')
 
       // Assert
-      expect(setStoredVersionSpy).not.toHaveBeenCalled()
+      expect(storedVersionSetSpy).not.toHaveBeenCalled()
       expect(notifyVersionUpdateSpy).not.toHaveBeenCalled()
     })
 
     it('should notify and update version when version changes', () => {
       // Arrange
       jest.spyOn(Storage, 'getStoredVersion').mockReturnValue('1.0.0')
-      const setStoredVersionSpy = jest
+      const storedVersionSetSpy = jest
         .spyOn(Storage, 'setStoredVersion')
         .mockImplementation()
       const notifyVersionUpdateSpy = jest
@@ -75,13 +75,13 @@ describe('VersionService', () => {
 
       // Assert
       expect(notifyVersionUpdateSpy).toHaveBeenCalledWith('1.0.0', '1.1.0')
-      expect(setStoredVersionSpy).toHaveBeenCalledWith('1.1.0')
+      expect(storedVersionSetSpy).toHaveBeenCalledWith('1.1.0')
     })
 
     it('should not update version when notification fails', () => {
       // Arrange
       jest.spyOn(Storage, 'getStoredVersion').mockReturnValue('1.0.0')
-      const setStoredVersionSpy = jest
+      const storedVersionSetSpy = jest
         .spyOn(Storage, 'setStoredVersion')
         .mockImplementation()
       const notifyVersionUpdateSpy = jest
@@ -95,7 +95,7 @@ describe('VersionService', () => {
 
       // Assert
       expect(notifyVersionUpdateSpy).toHaveBeenCalledWith('1.0.0', '1.1.0')
-      expect(setStoredVersionSpy).not.toHaveBeenCalled()
+      expect(storedVersionSetSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/src/__tests__/utils/async.test.ts
+++ b/src/__tests__/utils/async.test.ts
@@ -1,6 +1,6 @@
-import { AsyncUtils } from '@/utils/async'
+import { AsyncUtilities } from '@/utils/async'
 
-describe('AsyncUtils', () => {
+describe('AsyncUtilities', () => {
   beforeEach(() => {
     jest.useFakeTimers()
   })
@@ -12,7 +12,7 @@ describe('AsyncUtils', () => {
 
   describe('delay', () => {
     it('should delay for specified time', async () => {
-      const promise = AsyncUtils.delay(1000)
+      const promise = AsyncUtilities.delay(1000)
 
       // まだ解決されていないことを確認
       jest.advanceTimersByTime(999)
@@ -25,7 +25,7 @@ describe('AsyncUtils', () => {
 
     it('should be cancellable with AbortSignal', async () => {
       const controller = new AbortController()
-      const promise = AsyncUtils.delay(1000, controller.signal)
+      const promise = AsyncUtilities.delay(1000, controller.signal)
 
       controller.abort()
       await expect(promise).rejects.toThrow('Delay was aborted')
@@ -35,13 +35,13 @@ describe('AsyncUtils', () => {
       const controller = new AbortController()
       controller.abort()
 
-      const promise = AsyncUtils.delay(1000, controller.signal)
+      const promise = AsyncUtilities.delay(1000, controller.signal)
       await expect(promise).rejects.toThrow('Delay was aborted')
     })
 
     it('should cancel timeout when aborted during delay', async () => {
       const controller = new AbortController()
-      const promise = AsyncUtils.delay(1000, controller.signal)
+      const promise = AsyncUtilities.delay(1000, controller.signal)
 
       jest.advanceTimersByTime(500)
       controller.abort()
@@ -55,7 +55,7 @@ describe('AsyncUtils', () => {
     it('should delay for a random time between min and max', async () => {
       jest.spyOn(Math, 'random').mockReturnValue(0.5)
 
-      const promise = AsyncUtils.randomDelay(1000, 2000)
+      const promise = AsyncUtilities.randomDelay(1000, 2000)
 
       // 1500ms (min + 0.5 * (max - min))
       jest.advanceTimersByTime(1499)
@@ -67,7 +67,7 @@ describe('AsyncUtils', () => {
 
     it('should support cancellation', async () => {
       const controller = new AbortController()
-      const promise = AsyncUtils.randomDelay(1000, 2000, controller.signal)
+      const promise = AsyncUtilities.randomDelay(1000, 2000, controller.signal)
 
       controller.abort()
       await expect(promise).rejects.toThrow('Delay was aborted')
@@ -79,17 +79,17 @@ describe('AsyncUtils', () => {
       const baseMs = 1000
 
       // attempt 0: 1000ms
-      const promise0 = AsyncUtils.exponentialBackoff(baseMs, 0)
+      const promise0 = AsyncUtilities.exponentialBackoff(baseMs, 0)
       jest.advanceTimersByTime(1000)
       await expect(promise0).resolves.toBeUndefined()
 
       // attempt 1: 2000ms
-      const promise1 = AsyncUtils.exponentialBackoff(baseMs, 1)
+      const promise1 = AsyncUtilities.exponentialBackoff(baseMs, 1)
       jest.advanceTimersByTime(2000)
       await expect(promise1).resolves.toBeUndefined()
 
       // attempt 2: 4000ms
-      const promise2 = AsyncUtils.exponentialBackoff(baseMs, 2)
+      const promise2 = AsyncUtilities.exponentialBackoff(baseMs, 2)
       jest.advanceTimersByTime(4000)
       await expect(promise2).resolves.toBeUndefined()
     })
@@ -99,14 +99,14 @@ describe('AsyncUtils', () => {
       const maxMs = 3000
 
       // attempt 10 would be 1024000ms, but should be capped at 3000ms
-      const promise = AsyncUtils.exponentialBackoff(baseMs, 10, maxMs)
+      const promise = AsyncUtilities.exponentialBackoff(baseMs, 10, maxMs)
       jest.advanceTimersByTime(3000)
       await expect(promise).resolves.toBeUndefined()
     })
 
     it('should support cancellation', async () => {
       const controller = new AbortController()
-      const promise = AsyncUtils.exponentialBackoff(
+      const promise = AsyncUtilities.exponentialBackoff(
         1000,
         2,
         10_000,
@@ -126,7 +126,7 @@ describe('AsyncUtils', () => {
         }, 1000)
       })
 
-      const promise = AsyncUtils.withTimeout(operation, 2000)
+      const promise = AsyncUtilities.withTimeout(operation, 2000)
       jest.advanceTimersByTime(1000)
 
       await expect(promise).resolves.toBe('success')
@@ -139,7 +139,11 @@ describe('AsyncUtils', () => {
         }, 2000)
       })
 
-      const promise = AsyncUtils.withTimeout(operation, 1000, 'Custom timeout')
+      const promise = AsyncUtilities.withTimeout(
+        operation,
+        1000,
+        'Custom timeout'
+      )
       jest.advanceTimersByTime(1000)
 
       await expect(promise).rejects.toThrow('Custom timeout')
@@ -150,7 +154,7 @@ describe('AsyncUtils', () => {
         // Never resolves
       })
 
-      const promise = AsyncUtils.withTimeout(operation, 1000)
+      const promise = AsyncUtilities.withTimeout(operation, 1000)
       jest.advanceTimersByTime(1000)
 
       await expect(promise).rejects.toThrow('Operation timed out')
@@ -165,7 +169,7 @@ describe('AsyncUtils', () => {
         .mockRejectedValueOnce(new Error('2nd fail'))
         .mockResolvedValueOnce('success')
 
-      const promise = AsyncUtils.retry(operation, { maxAttempts: 3 })
+      const promise = AsyncUtilities.retry(operation, { maxAttempts: 3 })
 
       // 1回目の失敗
       await jest.advanceTimersByTimeAsync(0)
@@ -191,7 +195,7 @@ describe('AsyncUtils', () => {
         .mockRejectedValueOnce(new Error('2nd fail'))
         .mockRejectedValueOnce(new Error('3rd fail'))
 
-      const promise = AsyncUtils.retry(operation, {
+      const promise = AsyncUtilities.retry(operation, {
         maxAttempts: 3,
         baseDelay: 1, // Very short delay for testing
         useExponentialBackoff: false,
@@ -210,7 +214,7 @@ describe('AsyncUtils', () => {
         .mockRejectedValueOnce(new Error('2nd fail'))
         .mockResolvedValueOnce('success')
 
-      const promise = AsyncUtils.retry(operation, {
+      const promise = AsyncUtilities.retry(operation, {
         maxAttempts: 3,
         baseDelay: 500,
         useExponentialBackoff: false,
@@ -235,7 +239,7 @@ describe('AsyncUtils', () => {
       const controller = new AbortController()
       const operation = jest.fn().mockRejectedValue(new Error('Always fails'))
 
-      const promise = AsyncUtils.retry(operation, {
+      const promise = AsyncUtilities.retry(operation, {
         maxAttempts: 3,
         signal: controller.signal,
       })
@@ -251,7 +255,7 @@ describe('AsyncUtils', () => {
     it('should succeed on first attempt without delay', async () => {
       const operation = jest.fn().mockResolvedValueOnce('immediate success')
 
-      const result = await AsyncUtils.retry(operation)
+      const result = await AsyncUtilities.retry(operation)
 
       expect(result).toBe('immediate success')
       expect(operation).toHaveBeenCalledTimes(1)
@@ -263,7 +267,7 @@ describe('AsyncUtils', () => {
         .mockRejectedValueOnce(new Error('fail'))
         .mockResolvedValueOnce('success')
 
-      const promise = AsyncUtils.retry(operation)
+      const promise = AsyncUtilities.retry(operation)
 
       // デフォルトの指数バックオフ遅延
       await jest.advanceTimersByTimeAsync(0)

--- a/src/__tests__/utils/dom.test.ts
+++ b/src/__tests__/utils/dom.test.ts
@@ -1,4 +1,4 @@
-import { DomUtils } from '../../utils/dom'
+import { DomUtilities } from '../../utils/dom'
 import { TIMEOUTS } from '../../core/constants'
 
 // Mock timers
@@ -12,9 +12,9 @@ jest.useFakeTimers()
  * - ツイート返信の展開ボタンクリック機能
  * - X.com固有のDOMセレクターを使用した要素操作
  */
-describe('DomUtils', () => {
+describe('DomUtilities', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''
+    document.body.replaceChildren()
     jest.clearAllTimers()
     jest.clearAllMocks()
   })
@@ -34,7 +34,7 @@ describe('DomUtils', () => {
       testDiv.id = 'test-element'
       document.body.append(testDiv)
 
-      const promise = DomUtils.waitElement('#test-element')
+      const promise = DomUtilities.waitElement('#test-element')
 
       jest.advanceTimersByTime(TIMEOUTS.ELEMENT_WAIT)
       await expect(promise).resolves.toBeUndefined()
@@ -42,7 +42,7 @@ describe('DomUtils', () => {
 
     /** 要素が遅れて追加された場合でも正常に検出することを検証 */
     it('should resolve when element appears after some time', async () => {
-      const promise = DomUtils.waitElement('#delayed-element')
+      const promise = DomUtilities.waitElement('#delayed-element')
 
       // Advance timer partially
       jest.advanceTimersByTime(TIMEOUTS.ELEMENT_WAIT * 2)
@@ -59,7 +59,7 @@ describe('DomUtils', () => {
 
     /** タイムアウト時間内に要素が見つからない場合のエラー処理を検証 */
     it('should reject when element is not found within timeout', async () => {
-      const promise = DomUtils.waitElement('#non-existent', 1)
+      const promise = DomUtilities.waitElement('#non-existent', 1)
 
       jest.advanceTimersByTime(2000) // 2 seconds
 
@@ -70,7 +70,7 @@ describe('DomUtils', () => {
 
     /** タイムアウト時間が指定されていない場合のデフォルト値使用を検証 */
     it('should use default timeout when not specified', async () => {
-      const promise = DomUtils.waitElement('#non-existent')
+      const promise = DomUtilities.waitElement('#non-existent')
 
       jest.advanceTimersByTime(
         TIMEOUTS.ELEMENT_WAIT_LIMIT * 2 * TIMEOUTS.ELEMENT_WAIT
@@ -90,7 +90,7 @@ describe('DomUtils', () => {
       article.append(span)
       document.body.append(article)
 
-      const promise = DomUtils.waitElement(
+      const promise = DomUtilities.waitElement(
         'article[data-testid="tweet"] .tweet-text'
       )
 
@@ -116,6 +116,7 @@ describe('DomUtils', () => {
         'path'
       )
       /* eslint-enable unicorn/prefer-https */
+
       path.setAttribute(
         'd',
         'M12 4c-4.418 0-8 3.58-8 8s3.582 8 8 8c3.806 0 6.993-2.66 7.802-6.22l1.95.44C20.742 18.67 16.76 22 12 22 6.477 22 2 17.52 2 12S6.477 2 12 2c3.272 0 6.176 1.57 8 4V3.5h2v6h-6v-2h2.616C17.175 5.39 14.749 4 12 4z'
@@ -125,7 +126,7 @@ describe('DomUtils', () => {
       div.append(svg)
       document.body.append(div)
 
-      expect(DomUtils.isFailedPage()).toBe(true)
+      expect(DomUtilities.isFailedPage()).toBe(true)
     })
 
     /** エラーページのインジケーターが存在しない場合にfalseを返すことを検証 */
@@ -134,12 +135,12 @@ describe('DomUtils', () => {
       div.className = 'css-175oi2r'
       document.body.append(div)
 
-      expect(DomUtils.isFailedPage()).toBe(false)
+      expect(DomUtilities.isFailedPage()).toBe(false)
     })
 
     /** 空のドキュメントに対してfalseを返すことを検証 */
     it('should return false for empty document', () => {
-      expect(DomUtils.isFailedPage()).toBe(false)
+      expect(DomUtilities.isFailedPage()).toBe(false)
     })
   })
 
@@ -172,7 +173,7 @@ describe('DomUtils', () => {
 
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
-      DomUtils.clickMoreReplies()
+      DomUtilities.clickMoreReplies()
 
       expect(clickSpy).toHaveBeenCalled()
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -186,7 +187,7 @@ describe('DomUtils', () => {
     it('should do nothing when more replies button is not found', () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
-      DomUtils.clickMoreReplies()
+      DomUtilities.clickMoreReplies()
 
       expect(consoleSpy).not.toHaveBeenCalled()
       consoleSpy.mockRestore()
@@ -227,7 +228,7 @@ describe('DomUtils', () => {
 
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
-      DomUtils.clickMoreRepliesAggressive()
+      DomUtilities.clickMoreRepliesAggressive()
 
       expect(clickSpy).toHaveBeenCalled()
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -264,7 +265,7 @@ describe('DomUtils', () => {
 
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
-      DomUtils.clickMoreRepliesAggressive()
+      DomUtilities.clickMoreRepliesAggressive()
 
       expect(clickSpy).not.toHaveBeenCalled()
       expect(consoleSpy).not.toHaveBeenCalled()
@@ -281,12 +282,12 @@ describe('DomUtils', () => {
       cellInnerDiv.dataset.testid = 'cellInnerDiv'
 
       // Create two matching articles
-      for (let i = 0; i < 2; i++) {
+      for (let index = 0; index < 2; index++) {
         const outerDiv = document.createElement('div')
         const innerDiv = document.createElement('div')
         const article = document.createElement('article')
         article.setAttribute('tabindex', '-1')
-        article.textContent = `ツイート${i + 1}: さらに返信を表示する`
+        article.textContent = `ツイート${index + 1}: さらに返信を表示する`
 
         const button = document.createElement('button')
         button.setAttribute('role', 'button')
@@ -305,7 +306,7 @@ describe('DomUtils', () => {
 
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
-      DomUtils.clickMoreRepliesAggressive()
+      DomUtilities.clickMoreRepliesAggressive()
 
       expect(consoleSpy).toHaveBeenCalledTimes(2)
 
@@ -332,7 +333,7 @@ describe('DomUtils', () => {
 
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
 
-      DomUtils.clickMoreRepliesAggressive()
+      DomUtilities.clickMoreRepliesAggressive()
 
       expect(consoleSpy).not.toHaveBeenCalled()
 

--- a/src/__tests__/utils/error.test.ts
+++ b/src/__tests__/utils/error.test.ts
@@ -12,14 +12,14 @@ jest.useFakeTimers()
  */
 describe('ErrorHandler', () => {
   beforeEach(() => {
-    document.body.innerHTML = ''
+    document.body.replaceChildren()
     jest.clearAllTimers()
     jest.clearAllMocks()
   })
 
   afterEach(() => {
     // Clean up DOM elements after each test
-    document.body.innerHTML = ''
+    document.body.replaceChildren()
   })
 
   afterEach(() => {

--- a/src/__tests__/utils/page-error-handler.test.ts
+++ b/src/__tests__/utils/page-error-handler.test.ts
@@ -1,6 +1,6 @@
 import { PageErrorHandler } from '@/utils/page-error-handler'
-import { DomUtils } from '@/utils/dom'
-import { AsyncUtils } from '@/utils/async'
+import { DomUtilities } from '@/utils/dom'
+import { AsyncUtilities } from '@/utils/async'
 import { DELAYS } from '@/core/constants'
 
 // Mock dependencies
@@ -20,8 +20,8 @@ describe('PageErrorHandler', () => {
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
 
     // Setup default mocks
-    jest.mocked(DomUtils.isFailedPage).mockReturnValue(false)
-    jest.mocked(AsyncUtils.delay).mockResolvedValue()
+    jest.mocked(DomUtilities.isFailedPage).mockReturnValue(false)
+    jest.mocked(AsyncUtilities.delay).mockResolvedValue()
   })
 
   afterEach(() => {
@@ -31,7 +31,7 @@ describe('PageErrorHandler', () => {
 
   describe('handlePageError', () => {
     it('should detect failed page and log error', async () => {
-      jest.mocked(DomUtils.isFailedPage).mockReturnValue(true)
+      jest.mocked(DomUtilities.isFailedPage).mockReturnValue(true)
 
       await PageErrorHandler.handlePageError(
         'Test',
@@ -50,7 +50,9 @@ describe('PageErrorHandler', () => {
       )
 
       expect(consoleLogSpy).toHaveBeenCalledWith('Wait 1 minute and reload.')
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(DELAYS.ERROR_RELOAD_WAIT)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(
+        DELAYS.ERROR_RELOAD_WAIT
+      )
       // Note: location.reload is called but we skip testing it due to JSDOM limitations
     })
 
@@ -75,7 +77,7 @@ describe('PageErrorHandler', () => {
         { waitTime: customWaitTime }
       )
 
-      expect(AsyncUtils.delay).toHaveBeenCalledWith(customWaitTime)
+      expect(AsyncUtilities.delay).toHaveBeenCalledWith(customWaitTime)
     })
 
     it('should not reload when shouldReload is false', async () => {
@@ -86,7 +88,7 @@ describe('PageErrorHandler', () => {
         { shouldReload: false }
       )
 
-      expect(AsyncUtils.delay).not.toHaveBeenCalled()
+      expect(AsyncUtilities.delay).not.toHaveBeenCalled()
       // Note: shouldReload=false prevents location.reload from being called
     })
 
@@ -130,7 +132,7 @@ describe('PageErrorHandler', () => {
       mockElement.classList.add('test-selector')
       document.body.append(mockElement)
 
-      jest.mocked(DomUtils.waitElement).mockResolvedValue(undefined)
+      jest.mocked(DomUtilities.waitElement).mockResolvedValue(undefined)
 
       const result = await PageErrorHandler.waitForElementWithErrorHandling(
         '.test-selector',
@@ -139,7 +141,7 @@ describe('PageErrorHandler', () => {
       )
 
       expect(result).toBe(mockElement)
-      expect(DomUtils.waitElement).toHaveBeenCalledWith(
+      expect(DomUtilities.waitElement).toHaveBeenCalledWith(
         '.test-selector',
         undefined
       )
@@ -150,7 +152,7 @@ describe('PageErrorHandler', () => {
 
     it('should handle error and re-throw when element not found', async () => {
       const testError = new Error('Element not found')
-      jest.mocked(DomUtils.waitElement).mockRejectedValue(testError)
+      jest.mocked(DomUtilities.waitElement).mockRejectedValue(testError)
 
       await expect(
         PageErrorHandler.waitForElementWithErrorHandling(
@@ -169,7 +171,7 @@ describe('PageErrorHandler', () => {
       mockElement.classList.add('test-selector')
       document.body.append(mockElement)
 
-      jest.mocked(DomUtils.waitElement).mockResolvedValue(undefined)
+      jest.mocked(DomUtilities.waitElement).mockResolvedValue(undefined)
       const customTimeout = 5000
 
       await PageErrorHandler.waitForElementWithErrorHandling(
@@ -179,7 +181,7 @@ describe('PageErrorHandler', () => {
         { timeout: customTimeout }
       )
 
-      expect(DomUtils.waitElement).toHaveBeenCalledWith(
+      expect(DomUtilities.waitElement).toHaveBeenCalledWith(
         '.test-selector',
         customTimeout
       )
@@ -190,7 +192,7 @@ describe('PageErrorHandler', () => {
 
     it('should pass error options when handling error', async () => {
       const testError = new Error('Element not found')
-      jest.mocked(DomUtils.waitElement).mockRejectedValue(testError)
+      jest.mocked(DomUtilities.waitElement).mockRejectedValue(testError)
 
       await expect(
         PageErrorHandler.waitForElementWithErrorHandling(
@@ -215,7 +217,7 @@ describe('PageErrorHandler', () => {
       mockElement.classList.add('test-selector')
       document.body.append(mockElement)
 
-      jest.mocked(DomUtils.waitElement).mockResolvedValue(undefined)
+      jest.mocked(DomUtilities.waitElement).mockResolvedValue(undefined)
 
       // Create a named function to ensure stack trace detection
       // eslint-disable-next-line unicorn/consistent-function-scoping
@@ -234,7 +236,7 @@ describe('PageErrorHandler', () => {
 
     it('should auto-detect caller name with options when error occurs', async () => {
       const testError = new Error('Element not found')
-      jest.mocked(DomUtils.waitElement).mockRejectedValue(testError)
+      jest.mocked(DomUtilities.waitElement).mockRejectedValue(testError)
 
       // Create a named function to ensure stack trace detection
       // eslint-disable-next-line unicorn/consistent-function-scoping
@@ -433,7 +435,7 @@ describe('PageErrorHandler', () => {
     })
 
     it('should log error details in development mode', () => {
-      const originalEnv = process.env.NODE_ENV
+      const originalEnvironment = process.env.NODE_ENV
       process.env.NODE_ENV = 'development'
 
       const testError = new Error('Detailed error')
@@ -447,11 +449,11 @@ describe('PageErrorHandler', () => {
         testError
       )
 
-      process.env.NODE_ENV = originalEnv
+      process.env.NODE_ENV = originalEnvironment
     })
 
     it('should not log error details in production mode', () => {
-      const originalEnv = process.env.NODE_ENV
+      const originalEnvironment = process.env.NODE_ENV
       process.env.NODE_ENV = 'production'
 
       const testError = new Error('Detailed error')
@@ -465,7 +467,7 @@ describe('PageErrorHandler', () => {
         testError
       )
 
-      process.env.NODE_ENV = originalEnv
+      process.env.NODE_ENV = originalEnvironment
     })
 
     it('should auto-detect caller name when not provided', () => {
@@ -483,7 +485,7 @@ describe('PageErrorHandler', () => {
     })
 
     it('should auto-detect caller name with error details in development', () => {
-      const originalEnv = process.env.NODE_ENV
+      const originalEnvironment = process.env.NODE_ENV
       process.env.NODE_ENV = 'development'
 
       const testError = new Error('Detailed error')
@@ -503,7 +505,7 @@ describe('PageErrorHandler', () => {
         testError
       )
 
-      process.env.NODE_ENV = originalEnv
+      process.env.NODE_ENV = originalEnvironment
     })
   })
 
@@ -518,7 +520,7 @@ describe('PageErrorHandler', () => {
 
     it('should handle when Error constructor throws', () => {
       // Mock Error constructor to throw
-      const OriginalError = globalThis.Error
+      const OriginalError = Error
       globalThis.Error = jest.fn().mockImplementation(() => {
         throw new OriginalError('Error constructor failed')
       }) as any
@@ -532,7 +534,7 @@ describe('PageErrorHandler', () => {
 
     it('should return unknown for malformed stack traces', () => {
       // Mock Error to return a malformed stack
-      const OriginalError = globalThis.Error
+      const OriginalError = Error
       globalThis.Error = jest.fn().mockImplementation(() => ({
         stack: 'malformed stack trace without function names',
       })) as any
@@ -546,7 +548,7 @@ describe('PageErrorHandler', () => {
 
     it('should return unknown when stack is undefined', () => {
       // Mock Error to return no stack
-      const OriginalError = globalThis.Error
+      const OriginalError = Error
       globalThis.Error = jest.fn().mockImplementation(() => ({
         stack: undefined,
       })) as any

--- a/src/__tests__/utils/page-test-utilities.ts
+++ b/src/__tests__/utils/page-test-utilities.ts
@@ -69,16 +69,16 @@ export function setupUserscriptMocks(): void {
   // We'll create a minimal mock that doesn't interfere with JSDOM
   // Individual tests can mock location properties as needed using Object.defineProperty
 
-  // Mock window.scrollBy
-  Object.defineProperty(globalThis, 'scrollBy', {
-    value: jest.fn(),
-    writable: true,
-  })
-
-  // Mock window.innerHeight
-  Object.defineProperty(globalThis, 'innerHeight', {
-    value: 800,
-    writable: true,
+  // Mock window.scrollBy and window.innerHeight
+  Object.defineProperties(globalThis, {
+    scrollBy: {
+      value: jest.fn(),
+      writable: true,
+    },
+    innerHeight: {
+      value: 800,
+      writable: true,
+    },
   })
 }
 

--- a/src/__tests__/utils/scroll.test.ts
+++ b/src/__tests__/utils/scroll.test.ts
@@ -1,10 +1,10 @@
-import { ScrollUtils } from '../../utils/scroll'
-import { DomUtils } from '../../utils/dom'
+import { ScrollUtilities } from '../../utils/scroll'
+import { DomUtilities } from '../../utils/dom'
 import { TIMEOUTS, THRESHOLDS } from '../../core/constants'
 
-// Mock DomUtils
+// Mock DomUtilities
 jest.mock('../../utils/dom', () => ({
-  DomUtils: {
+  DomUtilities: {
     clickMoreReplies: jest.fn(),
     clickMoreRepliesAggressive: jest.fn(),
   },
@@ -15,14 +15,15 @@ jest.useFakeTimers()
 
 // Mock window.scrollBy and window.innerHeight
 const mockScrollBy = jest.fn()
-Object.defineProperty(globalThis, 'scrollBy', {
-  value: mockScrollBy,
-  writable: true,
-})
-
-Object.defineProperty(globalThis, 'innerHeight', {
-  value: 800,
-  writable: true,
+Object.defineProperties(globalThis, {
+  scrollBy: {
+    value: mockScrollBy,
+    writable: true,
+  },
+  innerHeight: {
+    value: 800,
+    writable: true,
+  },
 })
 
 // Mock document.body.scrollHeight
@@ -40,16 +41,16 @@ Object.defineProperty(document.body, 'scrollHeight', {
  * - 返信展開ボタンとの連携機能
  * - 指定回数のスクロール実行機能
  */
-describe('ScrollUtils', () => {
+describe('ScrollUtilities', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.clearAllTimers()
     mockScrollBy.mockClear()
-    ;(DomUtils.clickMoreReplies as jest.Mock).mockClear()
-    ;(DomUtils.clickMoreRepliesAggressive as jest.Mock).mockClear()
+    ;(DomUtilities.clickMoreReplies as jest.Mock).mockClear()
+    ;(DomUtilities.clickMoreRepliesAggressive as jest.Mock).mockClear()
 
     // Reset scroll state for clean tests
-    ScrollUtils.resetScrollState()
+    ScrollUtilities.resetScrollState()
 
     // Reset scroll height
     Object.defineProperty(document.body, 'scrollHeight', {
@@ -61,7 +62,7 @@ describe('ScrollUtils', () => {
 
   afterEach(() => {
     // Clean up any running intervals
-    ScrollUtils.resetScrollState()
+    ScrollUtilities.resetScrollState()
     jest.runOnlyPendingTimers()
   })
 
@@ -76,10 +77,14 @@ describe('ScrollUtils', () => {
         .spyOn(console, 'warn')
         .mockImplementation(() => {})
 
-      const promise = ScrollUtils.scrollPage()
+      const promise = ScrollUtilities.scrollPage()
 
       // Simulate reaching max fail scroll count
-      for (let i = 0; i < THRESHOLDS.MAX_FAIL_SCROLL_COUNT + 1; i++) {
+      for (
+        let index = 0;
+        index < THRESHOLDS.MAX_FAIL_SCROLL_COUNT + 1;
+        index++
+      ) {
         jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL)
       }
 
@@ -89,8 +94,8 @@ describe('ScrollUtils', () => {
         top: 800,
         behavior: 'smooth',
       })
-      expect(DomUtils.clickMoreReplies).toHaveBeenCalled()
-      expect(DomUtils.clickMoreRepliesAggressive).toHaveBeenCalled()
+      expect(DomUtilities.clickMoreReplies).toHaveBeenCalled()
+      expect(DomUtilities.clickMoreRepliesAggressive).toHaveBeenCalled()
       expect(consoleSpy).toHaveBeenCalledWith('scrollPage: failed scroll')
 
       consoleSpy.mockRestore()
@@ -105,7 +110,7 @@ describe('ScrollUtils', () => {
         .spyOn(console, 'warn')
         .mockImplementation(() => {})
 
-      const promise = ScrollUtils.scrollPage()
+      const promise = ScrollUtilities.scrollPage()
 
       // First scroll - height changes (success)
       jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL / 2)
@@ -120,7 +125,7 @@ describe('ScrollUtils', () => {
       jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL)
 
       // Continue failing until max count
-      for (let i = 1; i < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; i++) {
+      for (let index = 1; index < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; index++) {
         jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL)
       }
 
@@ -137,16 +142,16 @@ describe('ScrollUtils', () => {
     // TODO: Re-enable after improving fakeTimers setup (Issue #19)
     it.skip('should return immediately if scrolling is already in progress', async () => {
       // Start the first scroll
-      const promise1 = ScrollUtils.scrollPage()
+      const promise1 = ScrollUtilities.scrollPage()
 
       // Second call should resolve immediately
-      const promise2 = ScrollUtils.scrollPage()
+      const promise2 = ScrollUtilities.scrollPage()
 
       // Wait for second promise (should resolve immediately)
       await promise2
 
       // Clean up first scroll by triggering completion
-      for (let i = 0; i < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; i++) {
+      for (let index = 0; index < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; index++) {
         jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL)
       }
 
@@ -157,16 +162,16 @@ describe('ScrollUtils', () => {
     // TODO: Re-enable after improving timer mocks for state cleanup (Issue #19)
     it.skip('should properly reset scroll state with active interval', () => {
       // Start a scroll to create an interval
-      ScrollUtils.scrollPage()
+      ScrollUtilities.scrollPage()
 
       // Reset state
-      ScrollUtils.resetScrollState()
+      ScrollUtilities.resetScrollState()
 
       // Should be able to start a new scroll immediately
-      const promise = ScrollUtils.scrollPage()
+      const promise = ScrollUtilities.scrollPage()
 
       // Clean up
-      for (let i = 0; i < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; i++) {
+      for (let index = 0; index < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; index++) {
         jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL)
       }
 
@@ -177,23 +182,24 @@ describe('ScrollUtils', () => {
     // TODO: Re-enable by refining fakeTimers for multiple Promise handling (Issue #19)
     it.skip('should handle multiple scrollPage calls correctly', async () => {
       // First scroll starts normally
-      const promise1 = ScrollUtils.scrollPage()
+      const promise1 = ScrollUtilities.scrollPage()
 
       // Second scroll should return immediately (line 29 coverage)
-      const promise2 = ScrollUtils.scrollPage()
+      const promise2 = ScrollUtilities.scrollPage()
 
       // Check second promise resolves immediately
-      let promise2Resolved = false
-      promise2.then(() => {
-        promise2Resolved = true
-      })
+      let isPromise2Resolved = false
+      ;(async () => {
+        await promise2
+        isPromise2Resolved = true
+      })()
 
       // Allow microtasks to process
       await Promise.resolve()
-      expect(promise2Resolved).toBe(true)
+      expect(isPromise2Resolved).toBe(true)
 
       // Complete first scroll
-      for (let i = 0; i < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; i++) {
+      for (let index = 0; index < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; index++) {
         jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL)
       }
 
@@ -216,7 +222,7 @@ describe('ScrollUtils', () => {
         configurable: true,
       })
 
-      const promise = ScrollUtils.scrollPage()
+      const promise = ScrollUtilities.scrollPage()
 
       // Trigger one failure first
       jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL)
@@ -231,7 +237,7 @@ describe('ScrollUtils', () => {
       jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL)
 
       // Keep height same to reach max failures
-      for (let i = 0; i < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; i++) {
+      for (let index = 0; index < THRESHOLDS.MAX_FAIL_SCROLL_COUNT; index++) {
         jest.advanceTimersByTime(TIMEOUTS.SCROLL_INTERVAL)
       }
 
@@ -253,7 +259,7 @@ describe('ScrollUtils', () => {
     /** スクロールが即座に実行されることを検証 */
     it('should call scrollBy immediately', () => {
       const count = 3
-      ScrollUtils.scrollWithCount(count)
+      ScrollUtilities.scrollWithCount(count)
 
       // First scroll happens immediately
       expect(mockScrollBy).toHaveBeenCalledTimes(1)
@@ -265,7 +271,7 @@ describe('ScrollUtils', () => {
 
     /** ゼロ回数のスクロール指定が適切に処理されることを検証 */
     it('should handle zero count', async () => {
-      const promise = ScrollUtils.scrollWithCount(0)
+      const promise = ScrollUtilities.scrollWithCount(0)
 
       await expect(promise).resolves.toBeUndefined()
 
@@ -276,13 +282,13 @@ describe('ScrollUtils', () => {
     // TODO: Re-enable by extending fakeTimers or jest.setTimeout for timing logic (Issue #19)
     it.skip('should wait between scrolls', async () => {
       const count = 2
-      const promise = ScrollUtils.scrollWithCount(count)
+      const promise = ScrollUtilities.scrollWithCount(count)
 
       // First scroll happens immediately
       expect(mockScrollBy).toHaveBeenCalledTimes(1)
 
       // Advance timers for all setTimeout calls
-      for (let i = 0; i < count; i++) {
+      for (let index = 0; index < count; index++) {
         jest.advanceTimersByTime(TIMEOUTS.CRAWL_INTERVAL)
       }
 
@@ -292,7 +298,7 @@ describe('ScrollUtils', () => {
 
     /** 正しいパラメーターでスクロールが実行されることを検証 */
     it('should scroll with correct parameters', async () => {
-      const promise = ScrollUtils.scrollWithCount(1)
+      const promise = ScrollUtilities.scrollWithCount(1)
 
       // Advance timer to complete the setTimeout in scrollWithCount
       jest.advanceTimersByTime(TIMEOUTS.CRAWL_INTERVAL)

--- a/src/core/__mocks__/storage.ts
+++ b/src/core/__mocks__/storage.ts
@@ -32,8 +32,8 @@ interface MockStorage {
   setSavedTweets: jest.MockedFunction<
     (tweets: StorageData['savedTweets']) => void
   >
-  setLoginNotified: jest.MockedFunction<(value: boolean) => void>
-  setLockedNotified: jest.MockedFunction<(value: boolean) => void>
+  setLoginNotified: jest.MockedFunction<(isNotified: boolean) => void>
+  setLockedNotified: jest.MockedFunction<(isNotified: boolean) => void>
   setRetryCount: jest.MockedFunction<(count: number) => void>
   getStoredVersion: jest.MockedFunction<() => string>
   setStoredVersion: jest.MockedFunction<(version: string) => void>
@@ -112,12 +112,12 @@ const mockStorage: MockStorage = {
     )
   }),
 
-  setLoginNotified: jest.fn((value: boolean): void => {
-    GM_setValue('isLoginNotified', value)
+  setLoginNotified: jest.fn((isNotified: boolean): void => {
+    GM_setValue('isLoginNotified', isNotified)
   }),
 
-  setLockedNotified: jest.fn((value: boolean): void => {
-    GM_setValue('isLockedNotified', value)
+  setLockedNotified: jest.fn((isNotified: boolean): void => {
+    GM_setValue('isLockedNotified', isNotified)
   }),
 
   setRetryCount: jest.fn((count: number): void => {
@@ -177,9 +177,10 @@ const mockStorage: MockStorage = {
     for (const tweet of tweets) {
       savedTweetsMap.set(tweet.tweetId, tweet)
     }
-    const sortedTweets = [...savedTweetsMap.values()].toSorted((a, b) =>
-      a.tweetId.localeCompare(b.tweetId)
-    )
+    const sortedTweets = savedTweetsMap
+      .values()
+      .toArray()
+      .toSorted((a, b) => a.tweetId.localeCompare(b.tweetId))
     mockStorage.setSavedTweets(sortedTweets)
   }),
 

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -46,7 +46,7 @@ export class Storage {
    * @returns チェック済みツイートIDの配列
    */
   static getCheckedTweets(): string[] {
-    return Storage.getValue('checkedTweets', [])
+    return this.getValue('checkedTweets', [])
   }
 
   /**
@@ -56,8 +56,8 @@ export class Storage {
    * @returns チェック済みツイートIDのSet
    */
   static getCheckedTweetsSet(): Set<string> {
-    Storage._checkedTweetsSet ??= new Set(Storage.getCheckedTweets())
-    return Storage._checkedTweetsSet
+    this._checkedTweetsSet ??= new Set(this.getCheckedTweets())
+    return this._checkedTweetsSet
   }
 
   /**
@@ -66,7 +66,7 @@ export class Storage {
    * @returns 待機中ツイートIDの配列
    */
   static getWaitingTweets(): string[] {
-    return Storage.getValue('waitingTweets', [])
+    return this.getValue('waitingTweets', [])
   }
 
   /**
@@ -76,8 +76,8 @@ export class Storage {
    * @returns 待機中ツイートIDのSet
    */
   static getWaitingTweetsSet(): Set<string> {
-    Storage._waitingTweetsSet ??= new Set(Storage.getWaitingTweets())
-    return Storage._waitingTweetsSet
+    this._waitingTweetsSet ??= new Set(this.getWaitingTweets())
+    return this._waitingTweetsSet
   }
 
   /**
@@ -86,7 +86,7 @@ export class Storage {
    * @returns 保存済みツイートの配列
    */
   static getSavedTweets() {
-    return Storage.getValue('savedTweets', [])
+    return this.getValue('savedTweets', [])
   }
 
   /**
@@ -96,10 +96,10 @@ export class Storage {
    * @returns 保存済みツイートのMap（キー: tweetId）
    */
   static getSavedTweetsMap(): Map<string, Tweet> {
-    Storage._savedTweetsMap ??= new Map(
-      Storage.getSavedTweets().map((tweet) => [tweet.tweetId, tweet])
+    this._savedTweetsMap ??= new Map(
+      this.getSavedTweets().map((tweet) => [tweet.tweetId, tweet])
     )
-    return Storage._savedTweetsMap
+    return this._savedTweetsMap
   }
 
   /**
@@ -108,7 +108,7 @@ export class Storage {
    * @returns ログイン通知済みの場合 true
    */
   static isLoginNotified(): boolean {
-    return Storage.getValue('isLoginNotified', false)
+    return this.getValue('isLoginNotified', false)
   }
 
   /**
@@ -117,7 +117,7 @@ export class Storage {
    * @returns ロック通知済みの場合 true
    */
   static isLockedNotified(): boolean {
-    return Storage.getValue('isLockedNotified', false)
+    return this.getValue('isLockedNotified', false)
   }
 
   /**
@@ -126,7 +126,7 @@ export class Storage {
    * @returns 現在のリトライ回数
    */
   static getRetryCount(): number {
-    return Storage.getValue('retryCount', 0)
+    return this.getValue('retryCount', 0)
   }
 
   /**
@@ -135,9 +135,9 @@ export class Storage {
    * @param tweets - 保存するツイートIDの配列
    */
   static setCheckedTweets(tweets: string[]): void {
-    Storage.setValue('checkedTweets', tweets)
+    this.setValue('checkedTweets', tweets)
     // キャッシュを更新
-    Storage._checkedTweetsSet = new Set(tweets)
+    this._checkedTweetsSet = new Set(tweets)
   }
 
   /**
@@ -146,9 +146,9 @@ export class Storage {
    * @param tweets - 保存するツイートIDの配列
    */
   static setWaitingTweets(tweets: string[]): void {
-    Storage.setValue('waitingTweets', tweets)
+    this.setValue('waitingTweets', tweets)
     // キャッシュを更新
-    Storage._waitingTweetsSet = new Set(tweets)
+    this._waitingTweetsSet = new Set(tweets)
   }
 
   /**
@@ -157,9 +157,9 @@ export class Storage {
    * @param tweets - 保存するツイートの配列
    */
   static setSavedTweets(tweets: StorageData['savedTweets']): void {
-    Storage.setValue('savedTweets', tweets)
+    this.setValue('savedTweets', tweets)
     // キャッシュを更新
-    Storage._savedTweetsMap = new Map(
+    this._savedTweetsMap = new Map(
       tweets.map((tweet) => [tweet.tweetId, tweet])
     )
   }
@@ -167,19 +167,19 @@ export class Storage {
   /**
    * ログイン通知済みフラグを保存する
    *
-   * @param value - 保存する値
+   * @param isNotified - 保存する値
    */
-  static setLoginNotified(value: boolean): void {
-    Storage.setValue('isLoginNotified', value)
+  static setLoginNotified(isNotified: boolean): void {
+    this.setValue('isLoginNotified', isNotified)
   }
 
   /**
    * ロック通知済みフラグを保存する
    *
-   * @param value - 保存する値
+   * @param isNotified - 保存する値
    */
-  static setLockedNotified(value: boolean): void {
-    Storage.setValue('isLockedNotified', value)
+  static setLockedNotified(isNotified: boolean): void {
+    this.setValue('isLockedNotified', isNotified)
   }
 
   /**
@@ -188,7 +188,7 @@ export class Storage {
    * @param count - 保存するリトライ回数
    */
   static setRetryCount(count: number): void {
-    Storage.setValue('retryCount', count)
+    this.setValue('retryCount', count)
   }
 
   /**
@@ -197,7 +197,7 @@ export class Storage {
    * @returns 保存済みバージョン文字列
    */
   static getStoredVersion(): string {
-    return Storage.getValue('storedVersion', '')
+    return this.getValue('storedVersion', '')
   }
 
   /**
@@ -206,16 +206,16 @@ export class Storage {
    * @param version - 保存するバージョン文字列
    */
   static setStoredVersion(version: string): void {
-    Storage.setValue('storedVersion', version)
+    this.setValue('storedVersion', version)
   }
 
   /**
    * キャッシュをクリア（主にテスト用）
    */
   static clearCache(): void {
-    Storage._checkedTweetsSet = null
-    Storage._waitingTweetsSet = null
-    Storage._savedTweetsMap = null
+    this._checkedTweetsSet = null
+    this._waitingTweetsSet = null
+    this._savedTweetsMap = null
   }
 
   /**
@@ -224,11 +224,11 @@ export class Storage {
    * @param tweetIds - 追加するツイートIDの配列
    */
   static addCheckedTweetsBatch(tweetIds: string[]): void {
-    const checkedTweetsSet = Storage.getCheckedTweetsSet()
+    const checkedTweetsSet = this.getCheckedTweetsSet()
     for (const tweetId of tweetIds) {
       checkedTweetsSet.add(tweetId)
     }
-    Storage.setCheckedTweets([...checkedTweetsSet])
+    this.setCheckedTweets([...checkedTweetsSet])
   }
 
   /**
@@ -237,11 +237,11 @@ export class Storage {
    * @param tweetIds - 追加するツイートIDの配列
    */
   static addWaitingTweetsBatch(tweetIds: string[]): void {
-    const waitingTweetsSet = Storage.getWaitingTweetsSet()
+    const waitingTweetsSet = this.getWaitingTweetsSet()
     for (const tweetId of tweetIds) {
       waitingTweetsSet.add(tweetId)
     }
-    Storage.setWaitingTweets([...waitingTweetsSet])
+    this.setWaitingTweets([...waitingTweetsSet])
   }
 
   /**
@@ -250,14 +250,15 @@ export class Storage {
    * @param tweets - 保存するツイートの配列
    */
   static saveTweetsBatch(tweets: Tweet[]): void {
-    const savedTweetsMap = Storage.getSavedTweetsMap()
+    const savedTweetsMap = this.getSavedTweetsMap()
     for (const tweet of tweets) {
       savedTweetsMap.set(tweet.tweetId, tweet)
     }
-    const sortedTweets = [...savedTweetsMap.values()].toSorted((a, b) =>
-      a.tweetId.localeCompare(b.tweetId)
-    )
-    Storage.setSavedTweets(sortedTweets)
+    const sortedTweets = savedTweetsMap
+      .values()
+      .toArray()
+      .toSorted((a, b) => a.tweetId.localeCompare(b.tweetId))
+    this.setSavedTweets(sortedTweets)
   }
 
   /**
@@ -271,8 +272,8 @@ export class Storage {
     isWaiting: boolean
   } {
     return {
-      isChecked: Storage.getCheckedTweetsSet().has(tweetId),
-      isWaiting: Storage.getWaitingTweetsSet().has(tweetId),
+      isChecked: this.getCheckedTweetsSet().has(tweetId),
+      isWaiting: this.getWaitingTweetsSet().has(tweetId),
     }
   }
 
@@ -283,7 +284,7 @@ export class Storage {
    * @returns ツイートオブジェクトまたはundefined
    */
   static getSavedTweetById(tweetId: string): Tweet | undefined {
-    return Storage.getSavedTweetsMap().get(tweetId)
+    return this.getSavedTweetsMap().get(tweetId)
   }
 
   /**
@@ -302,13 +303,13 @@ export class Storage {
     }
   } {
     return {
-      checkedTweetsCount: Storage.getCheckedTweetsSet().size,
-      waitingTweetsCount: Storage.getWaitingTweetsSet().size,
-      savedTweetsCount: Storage.getSavedTweetsMap().size,
+      checkedTweetsCount: this.getCheckedTweetsSet().size,
+      waitingTweetsCount: this.getWaitingTweetsSet().size,
+      savedTweetsCount: this.getSavedTweetsMap().size,
       memoryUsage: {
-        checkedTweetsSetSize: Storage._checkedTweetsSet?.size ?? 0,
-        waitingTweetsSetSize: Storage._waitingTweetsSet?.size ?? 0,
-        savedTweetsMapSize: Storage._savedTweetsMap?.size ?? 0,
+        checkedTweetsSetSize: this._checkedTweetsSet?.size ?? 0,
+        waitingTweetsSetSize: this._waitingTweetsSet?.size ?? 0,
+        savedTweetsMapSize: this._savedTweetsMap?.size ?? 0,
       },
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import {
   OtherPages,
 } from '@/pages'
 import packageJson from '../package.json'
-;(function () {
+{
   const methods: PageMethod[] = [
     {
       url: URLS.HOME,
@@ -77,29 +77,29 @@ import packageJson from '../package.json'
     {
       url: URLS.EXAMPLE_LOGIN_NOTIFY,
       urlType: 'startsWith',
-      run: () => {
-        ExamplePages.runLoginNotify()
+      run: async () => {
+        await ExamplePages.runLoginNotify()
       },
     },
     {
       url: URLS.EXAMPLE_LOGIN_SUCCESS_NOTIFY,
       urlType: 'startsWith',
-      run: () => {
-        ExamplePages.runLoginSuccessNotify()
+      run: async () => {
+        await ExamplePages.runLoginSuccessNotify()
       },
     },
     {
       url: URLS.EXAMPLE_LOCKED_NOTIFY,
       urlType: 'startsWith',
-      run: () => {
-        ExamplePages.runLockedNotify()
+      run: async () => {
+        await ExamplePages.runLockedNotify()
       },
     },
     {
       url: URLS.EXAMPLE_UNLOCKED_NOTIFY,
       urlType: 'startsWith',
-      run: () => {
-        ExamplePages.runUnlockedNotify()
+      run: async () => {
+        await ExamplePages.runUnlockedNotify()
       },
     },
     {
@@ -112,8 +112,8 @@ import packageJson from '../package.json'
     {
       url: URLS.EXAMPLE_UPDATE_NOTIFY,
       urlType: 'startsWith',
-      run: () => {
-        ExamplePages.runUpdateNotify()
+      run: async () => {
+        await ExamplePages.runUpdateNotify()
       },
     },
   ]
@@ -125,7 +125,8 @@ import packageJson from '../package.json'
         location.href.startsWith(method.url as string)
       ) {
         return true
-      } else if (
+      }
+      if (
         method.urlType === 'regex' &&
         (method.url as RegExp).test(location.href)
       ) {
@@ -177,26 +178,26 @@ import packageJson from '../package.json'
   if (document.readyState === 'complete') {
     console.log('Page already loaded, waiting for a moment before running...')
     setTimeout(() => {
-      try {
-        run().catch((error: unknown) => {
+      ;(async () => {
+        try {
+          await run()
+        } catch (error: unknown) {
           console.error('Error in run():', error)
-        })
-      } catch (error: unknown) {
-        console.error('Error starting script:', error)
-      }
+        }
+      })()
     }, 1000)
   } else {
     window.addEventListener('load', () => {
       console.log('Page loaded, waiting for network stability...')
       setTimeout(() => {
-        try {
-          run().catch((error: unknown) => {
+        ;(async () => {
+          try {
+            await run()
+          } catch (error: unknown) {
             console.error('Error in run():', error)
-          })
-        } catch (error: unknown) {
-          console.error('Error starting script:', error)
-        }
+          }
+        })()
       }, 2000)
     })
   }
-})()
+}

--- a/src/pages/example-pages.ts
+++ b/src/pages/example-pages.ts
@@ -4,99 +4,99 @@ import { ConfigManager } from '@/core/config'
 import { TweetService } from '@/services/tweet-service'
 import { QueueService } from '@/services/queue-service'
 import { NotificationService } from '@/services/notification-service'
-import { AsyncUtils } from '@/utils/async'
+import { AsyncUtilities } from '@/utils/async'
 import { PageErrorHandler } from '@/utils/page-error-handler'
 import { TweetPage } from './tweet-page'
 
 export const ExamplePages = {
   async runDownloadJson(): Promise<void> {
-    const ifNeeded = TweetService.isNeedDownload()
+    const isIfNeeded = TweetService.isNeedDownload()
 
-    if (ifNeeded) {
+    if (isIfNeeded) {
       PageErrorHandler.logAction('download needed. Wait 5 seconds.')
       TweetService.downloadTweets()
-      await AsyncUtils.delay(DELAYS.DOWNLOAD_WAIT)
+      await AsyncUtilities.delay(DELAYS.DOWNLOAD_WAIT)
     }
 
-    TweetPage.run(true).catch((error: unknown) => {
-      PageErrorHandler.logError('Error in TweetPage.run', error)
-    })
+    ;(async () => {
+      try {
+        await TweetPage.run(true)
+      } catch (error: unknown) {
+        PageErrorHandler.logError('Error in TweetPage.run', error)
+      }
+    })()
   },
 
-  runLoginNotify(): void {
+  async runLoginNotify(): Promise<void> {
     const authWebhookUrl = ConfigManager.getAuthWebhookUrl()
-    NotificationService.notifyDiscord(
-      ':key: Need to login.',
-      () => {
-        window.close()
-        Storage.setLoginNotified(true)
-      },
-      false,
-      authWebhookUrl
-    )
-      .then(() => {
-        PageErrorHandler.logAction('Notification sent successfully')
-      })
-      .catch((error: unknown) => {
-        PageErrorHandler.logError('Failed to notify login', error)
-      })
+    try {
+      await NotificationService.notifyDiscord(
+        ':key: Need to login.',
+        () => {
+          window.close()
+          Storage.setLoginNotified(true)
+        },
+        false,
+        authWebhookUrl
+      )
+      PageErrorHandler.logAction('Notification sent successfully')
+    } catch (error: unknown) {
+      PageErrorHandler.logError('Failed to notify login', error)
+    }
   },
 
-  runLoginSuccessNotify(): void {
+  async runLoginSuccessNotify(): Promise<void> {
     const authWebhookUrl = ConfigManager.getAuthWebhookUrl()
-    NotificationService.notifyDiscord(
-      ':white_check_mark: Login is successful!',
-      () => {
-        window.close()
-      },
-      false,
-      authWebhookUrl
-    )
-      .then(() => {
-        PageErrorHandler.logAction('Notification sent successfully')
-      })
-      .catch((error: unknown) => {
-        PageErrorHandler.logError('Failed to notify login success', error)
-      })
+    try {
+      await NotificationService.notifyDiscord(
+        ':white_check_mark: Login is successful!',
+        () => {
+          window.close()
+        },
+        false,
+        authWebhookUrl
+      )
+      PageErrorHandler.logAction('Notification sent successfully')
+    } catch (error: unknown) {
+      PageErrorHandler.logError('Failed to notify login success', error)
+    }
   },
 
-  runLockedNotify(): void {
+  async runLockedNotify(): Promise<void> {
     const lockWebhookUrl = ConfigManager.getLockWebhookUrl()
-    NotificationService.notifyDiscord(
-      ':lock: Account is locked!',
-      () => {
-        window.close()
-        // 通知送信成功時のコールバックは空にする（フラグは事前に設定済み）
-      },
-      true,
-      lockWebhookUrl
-    )
-      .then(() => {
-        PageErrorHandler.logAction('Notification sent successfully')
-      })
-      .catch((error: unknown) => {
-        // 通知送信失敗時はフラグをリセット
-        Storage.setLockedNotified(false)
-        PageErrorHandler.logError('Failed to notify account locked', error)
-      })
+    try {
+      await NotificationService.notifyDiscord(
+        ':lock: Account is locked!',
+        () => {
+          window.close()
+          // 通知送信成功時のコールバックは空にする（フラグは事前に設定済み）
+        },
+        true,
+        lockWebhookUrl
+      )
+      PageErrorHandler.logAction('Notification sent successfully')
+    } catch (error: unknown) {
+      // 通知送信失敗時はフラグをリセット
+      Storage.setLockedNotified(false)
+      PageErrorHandler.logError('Failed to notify account locked', error)
+    }
   },
 
-  runUnlockedNotify(): void {
+  async runUnlockedNotify(): Promise<void> {
     const lockWebhookUrl = ConfigManager.getLockWebhookUrl()
-    NotificationService.notifyDiscord(
-      ':unlock: Account is unlocked.',
-      () => {
-        window.close()
-      },
-      false,
-      lockWebhookUrl
-    )
-      .then(() => {
-        PageErrorHandler.logAction('Notification sent successfully')
-      })
-      .catch((error: unknown) => {
-        PageErrorHandler.logError('Failed to notify account unlocked', error)
-      })
+    try {
+      await NotificationService.notifyDiscord(
+        ':unlock: Account is unlocked.',
+        () => {
+          window.close()
+        },
+        false,
+        lockWebhookUrl
+      )
+      PageErrorHandler.logAction('Notification sent successfully')
+    } catch (error: unknown) {
+      PageErrorHandler.logError('Failed to notify account unlocked', error)
+    }
   },
 
   runResetWaiting(): void {
@@ -106,14 +106,14 @@ export const ExamplePages = {
     )
 
     setTimeout(() => {
-      location.href = URLS.HOME
+      location.assign(URLS.HOME)
     }, DELAYS.RESET_REDIRECT_WAIT)
   },
 
-  runUpdateNotify(): void {
-    const params = new URLSearchParams(globalThis.location.search)
-    const oldVersion = params.get('old')
-    const newVersion = params.get('new')
+  async runUpdateNotify(): Promise<void> {
+    const parameters = new URLSearchParams(globalThis.location.search)
+    const oldVersion = parameters.get('old')
+    const newVersion = parameters.get('new')
 
     if (!oldVersion || !newVersion) {
       PageErrorHandler.logError('Missing version parameters')
@@ -121,20 +121,19 @@ export const ExamplePages = {
       return
     }
 
-    NotificationService.notifyDiscord(
-      `🚀 Twitter Auto Spam Crawler がアップデートされました!\n` +
-        `📦 ${oldVersion} → ${newVersion}\n` +
-        `✨ 新しいバージョンが適用されました。`,
-      () => {
-        window.close()
-      },
-      true
-    )
-      .then(() => {
-        PageErrorHandler.logAction('Update notification sent successfully')
-      })
-      .catch((error: unknown) => {
-        PageErrorHandler.logError('Failed to notify update', error)
-      })
+    try {
+      await NotificationService.notifyDiscord(
+        `🚀 Twitter Auto Spam Crawler がアップデートされました!\n` +
+          `📦 ${oldVersion} → ${newVersion}\n` +
+          `✨ 新しいバージョンが適用されました。`,
+        () => {
+          window.close()
+        },
+        true
+      )
+      PageErrorHandler.logAction('Update notification sent successfully')
+    } catch (error: unknown) {
+      PageErrorHandler.logError('Failed to notify update', error)
+    }
   },
 }

--- a/src/pages/explore-page.ts
+++ b/src/pages/explore-page.ts
@@ -1,20 +1,20 @@
 import { StateService } from '@/services/state-service'
-import { DomUtils } from '@/utils/dom'
+import { DomUtilities } from '@/utils/dom'
 import { PageErrorHandler } from '@/utils/page-error-handler'
 
 export const ExplorePage = {
   async run(): Promise<void> {
-    if (DomUtils.checkAndNavigateToLogin()) {
+    if (DomUtilities.checkAndNavigateToLogin()) {
       return
     }
 
     StateService.resetState()
 
     try {
-      await DomUtils.waitElement('div[data-testid="trend"]')
+      await DomUtilities.waitElement('div[data-testid="trend"]')
     } catch (error) {
       await PageErrorHandler.handlePageError('Explore', 'runExplore', error, {
-        customMessage: DomUtils.isFailedPage()
+        customMessage: DomUtilities.isFailedPage()
           ? 'runExplore: failed page. Wait 1 minute and reload.'
           : 'Wait 1 minute and reload.',
       })

--- a/src/pages/home-page.ts
+++ b/src/pages/home-page.ts
@@ -2,13 +2,13 @@ import { URLS, DELAYS } from '@/core/constants'
 import { ConfigManager } from '@/core/config'
 import { StateService } from '@/services/state-service'
 import { CrawlerService } from '@/services/crawler-service'
-import { DomUtils } from '@/utils/dom'
-import { AsyncUtils } from '@/utils/async'
+import { DomUtilities } from '@/utils/dom'
+import { AsyncUtilities } from '@/utils/async'
 import { PageErrorHandler } from '@/utils/page-error-handler'
 
 export const HomePage = {
   async run(): Promise<void> {
-    if (DomUtils.checkAndNavigateToLogin()) {
+    if (DomUtilities.checkAndNavigateToLogin()) {
       return
     }
 
@@ -17,7 +17,7 @@ export const HomePage = {
     CrawlerService.startCrawling()
 
     try {
-      await DomUtils.waitElement(
+      await DomUtilities.waitElement(
         'div[data-testid="primaryColumn"] nav[aria-live="polite"][role="navigation"] div[role="tablist"] > div[role="presentation"] a[role="tab"]'
       )
     } catch (error) {
@@ -25,7 +25,7 @@ export const HomePage = {
       return
     }
 
-    await AsyncUtils.delay(DELAYS.LONG * 3)
+    await AsyncUtilities.delay(DELAYS.LONG * 3)
 
     const tabs = document.querySelectorAll(
       'div[data-testid="primaryColumn"] nav[aria-live="polite"][role="navigation"] div[role="tablist"] > div[role="presentation"] a[role="tab"]'
@@ -37,11 +37,11 @@ export const HomePage = {
       PageErrorHandler.logAction(`open tab=${tabIndex}`)
       tab.click()
 
-      await AsyncUtils.delay(DELAYS.CRAWL_INTERVAL)
+      await AsyncUtilities.delay(DELAYS.CRAWL_INTERVAL)
       try {
-        await DomUtils.waitElement('article[data-testid="tweet"]')
+        await DomUtilities.waitElement('article[data-testid="tweet"]')
       } catch (error) {
-        if (DomUtils.isFailedPage()) {
+        if (DomUtilities.isFailedPage()) {
           await PageErrorHandler.handlePageError('Home', 'runHome', error, {
             customMessage: 'runHome: failed page. Wait 1 minute and reload.',
           })
@@ -57,18 +57,18 @@ export const HomePage = {
           top: window.innerHeight,
           behavior: 'smooth',
         })
-        await AsyncUtils.delay(DELAYS.CRAWL_INTERVAL)
+        await AsyncUtilities.delay(DELAYS.CRAWL_INTERVAL)
       }
     }
 
     const isOnlyHome = ConfigManager.getIsOnlyHome()
     if (isOnlyHome) {
       PageErrorHandler.logAction('isOnlyHome is true. Go to home page.')
-      location.href = URLS.HOME
+      location.assign(URLS.HOME)
       return
     }
 
     PageErrorHandler.logAction('all tabs are opened. Go to explore page.')
-    location.href = URLS.EXPLORE
+    location.assign(URLS.EXPLORE)
   },
 }

--- a/src/pages/other-pages.ts
+++ b/src/pages/other-pages.ts
@@ -1,6 +1,6 @@
 import { URLS, DELAYS } from '@/core/constants'
 import { Storage } from '@/core/storage'
-import { AsyncUtils } from '@/utils/async'
+import { AsyncUtilities } from '@/utils/async'
 import { PageErrorHandler } from '@/utils/page-error-handler'
 
 /**
@@ -32,7 +32,7 @@ export const OtherPages = {
         `Periodic check ${checkCount} - navigating to bookmark page to test unlock status`
       )
 
-      location.href = URLS.BOOKMARK
+      location.assign(URLS.BOOKMARK)
     }, DELAYS.LOCKED_CHECK_INTERVAL)
   },
 
@@ -45,7 +45,7 @@ export const OtherPages = {
     PageErrorHandler.logAction('start')
 
     PageErrorHandler.logAction('waiting for 60 seconds to process queue.')
-    await AsyncUtils.delay(DELAYS.PROCESSING_WAIT)
+    await AsyncUtilities.delay(DELAYS.PROCESSING_WAIT)
 
     PageErrorHandler.logAction(
       'checking for #injected-blue-block-toasts > div.toast'
@@ -57,7 +57,7 @@ export const OtherPages = {
       if (toastElements.length === 0) {
         PageErrorHandler.logAction('all toasts are gone.')
         clearInterval(interval)
-        location.href = URLS.HOME
+        location.assign(URLS.HOME)
       } else {
         PageErrorHandler.logAction(
           `still waiting for toasts: ${toastElements.length}`

--- a/src/pages/search-page.ts
+++ b/src/pages/search-page.ts
@@ -1,32 +1,32 @@
 import { DELAYS } from '@/core/constants'
 import { StateService } from '@/services/state-service'
 import { CrawlerService } from '@/services/crawler-service'
-import { DomUtils } from '@/utils/dom'
-import { AsyncUtils } from '@/utils/async'
+import { DomUtilities } from '@/utils/dom'
+import { AsyncUtilities } from '@/utils/async'
 import { PageErrorHandler } from '@/utils/page-error-handler'
 import { TweetPage } from './tweet-page'
 
 export const SearchPage = {
   async run(): Promise<void> {
-    if (DomUtils.checkAndNavigateToLogin()) {
+    if (DomUtilities.checkAndNavigateToLogin()) {
       return
     }
 
     StateService.resetState()
 
     if (!location.search.includes('f=live')) {
-      await AsyncUtils.delay(DELAYS.CRAWL_INTERVAL)
-      location.search = location.search + '&f=live'
+      await AsyncUtilities.delay(DELAYS.CRAWL_INTERVAL)
+      location.search += '&f=live'
       return
     }
 
     CrawlerService.startCrawling()
 
     try {
-      await DomUtils.waitElement('article[data-testid="tweet"]')
+      await DomUtilities.waitElement('article[data-testid="tweet"]')
     } catch (error) {
       await PageErrorHandler.handlePageError('Search', 'runSearch', error, {
-        customMessage: DomUtils.isFailedPage()
+        customMessage: DomUtilities.isFailedPage()
           ? 'runSearch: failed page. Wait 1 minute and reload.'
           : 'Wait 1 minute and reload.',
       })
@@ -38,11 +38,15 @@ export const SearchPage = {
         top: window.innerHeight,
         behavior: 'smooth',
       })
-      await AsyncUtils.delay(DELAYS.CRAWL_INTERVAL)
+      await AsyncUtilities.delay(DELAYS.CRAWL_INTERVAL)
     }
 
-    TweetPage.run(true).catch((error: unknown) => {
-      PageErrorHandler.logError('Error in TweetPage.run', error)
-    })
+    ;(async () => {
+      try {
+        await TweetPage.run(true)
+      } catch (error: unknown) {
+        PageErrorHandler.logError('Error in TweetPage.run', error)
+      }
+    })()
   },
 }

--- a/src/pages/tweet-page.ts
+++ b/src/pages/tweet-page.ts
@@ -4,87 +4,107 @@ import { StateService } from '@/services/state-service'
 import { CrawlerService } from '@/services/crawler-service'
 import { QueueService } from '@/services/queue-service'
 import { TweetService } from '@/services/tweet-service'
-import { DomUtils } from '@/utils/dom'
-import { ScrollUtils } from '@/utils/scroll'
+import { DomUtilities } from '@/utils/dom'
+import { ScrollUtilities } from '@/utils/scroll'
 import { ErrorHandler } from '@/utils/error'
 import { PageErrorHandler } from '@/utils/page-error-handler'
 
 export const TweetPage = {
-  async run(onlyOpen = false): Promise<void> {
-    if (DomUtils.checkAndNavigateToLogin()) {
+  async run(isOnlyOpen = false): Promise<void> {
+    if (DomUtilities.checkAndNavigateToLogin()) {
       return
     }
 
     StateService.resetState()
 
-    if (onlyOpen) {
+    if (isOnlyOpen) {
       if (TweetService.isNeedDownload()) {
-        location.href = URLS.EXAMPLE_DOWNLOAD_JSON
+        location.assign(URLS.EXAMPLE_DOWNLOAD_JSON)
         return
       }
 
       const nextTweetId = QueueService.getNextWaitingTweet()
       if (nextTweetId === null) {
-        location.href = URLS.BOOKMARK
+        location.assign(URLS.BOOKMARK)
         return
       }
 
       const tweetUrl = `https://x.com/user/status/${nextTweetId}`
-      location.href = tweetUrl
+      location.assign(tweetUrl)
       return
     }
 
     CrawlerService.startCrawling()
+    ;(async () => {
+      try {
+        await ErrorHandler.handleErrorDialog(async (dialog) => {
+          const dialogMessage = dialog.textContent
+          PageErrorHandler.logError('found error dialog', dialogMessage)
 
-    ErrorHandler.handleErrorDialog(async (dialog) => {
-      const dialogMessage = dialog.textContent
-      PageErrorHandler.logError('found error dialog', dialogMessage)
+          if (!dialogMessage) {
+            return
+          }
 
-      if (!dialogMessage) {
-        return
+          if (
+            dialogMessage.includes('削除') ||
+            dialogMessage.includes('deleted')
+          ) {
+            PageErrorHandler.logError('tweet deleted. Skip this tweet.')
+
+            const tweetUrlMatch = TWEET_URL_REGEX.exec(location.href)
+            if (tweetUrlMatch) {
+              const tweetId = tweetUrlMatch[2]
+              await QueueService.checkedTweet(tweetId)
+              CrawlerService.resetCrawledTweetCount()
+            }
+
+            ;(async () => {
+              try {
+                await TweetPage.run(true)
+              } catch (error: unknown) {
+                PageErrorHandler.logError('Error in TweetPage.run', error)
+              }
+            })()
+          }
+        }, 300_000)
+      } catch (error: unknown) {
+        PageErrorHandler.logError('Error in handleErrorDialog', error)
       }
+    })()
+    ;(async () => {
+      try {
+        await ErrorHandler.detectUnprocessablePost(
+          async (tweetArticleElement) => {
+            PageErrorHandler.logError(
+              "found can't processing post",
+              tweetArticleElement
+            )
 
-      if (dialogMessage.includes('削除') || dialogMessage.includes('deleted')) {
-        PageErrorHandler.logError('tweet deleted. Skip this tweet.')
+            const tweetUrlMatch = TWEET_URL_REGEX.exec(location.href)
+            if (tweetUrlMatch) {
+              const tweetId = tweetUrlMatch[2]
+              await QueueService.checkedTweet(tweetId)
+              CrawlerService.resetCrawledTweetCount()
+            }
 
-        const tweetUrlMatch = TWEET_URL_REGEX.exec(location.href)
-        if (tweetUrlMatch) {
-          const tweetId = tweetUrlMatch[2]
-          await QueueService.checkedTweet(tweetId)
-          CrawlerService.resetCrawledTweetCount()
-        }
-
-        TweetPage.run(true).catch((error: unknown) => {
-          PageErrorHandler.logError('Error in TweetPage.run', error)
-        })
+            ;(async () => {
+              try {
+                await TweetPage.run(true)
+              } catch (error: unknown) {
+                PageErrorHandler.logError('Error in TweetPage.run', error)
+              }
+            })()
+          },
+          300_000
+        )
+      } catch (error: unknown) {
+        PageErrorHandler.logError('Error in detectUnprocessablePost', error)
       }
-    }, 300_000).catch((error: unknown) => {
-      PageErrorHandler.logError('Error in handleErrorDialog', error)
-    })
-
-    ErrorHandler.detectUnprocessablePost(async (tweetArticleElement) => {
-      PageErrorHandler.logError(
-        "found can't processing post",
-        tweetArticleElement
-      )
-
-      const tweetUrlMatch = TWEET_URL_REGEX.exec(location.href)
-      if (tweetUrlMatch) {
-        const tweetId = tweetUrlMatch[2]
-        await QueueService.checkedTweet(tweetId)
-        CrawlerService.resetCrawledTweetCount()
-      }
-
-      TweetPage.run(true).catch((error: unknown) => {
-        PageErrorHandler.logError('Error in TweetPage.run', error)
-      })
-    }, 300_000).catch((error: unknown) => {
-      PageErrorHandler.logError('Error in detectUnprocessablePost', error)
-    })
+    })()
 
     const retryCount = Storage.getRetryCount()
     try {
-      await DomUtils.waitElement('article[data-testid="tweet"]')
+      await DomUtilities.waitElement('article[data-testid="tweet"]')
     } catch (error) {
       if (retryCount >= THRESHOLDS.MAX_RETRY_COUNT) {
         PageErrorHandler.logError(
@@ -97,9 +117,13 @@ export const TweetPage = {
           const tweetId = tweetUrlMatch[2]
           await QueueService.checkedTweet(tweetId)
         }
-        TweetPage.run(true).catch((error: unknown) => {
-          PageErrorHandler.logError('Error in TweetPage.run', error)
-        })
+        ;(async () => {
+          try {
+            await TweetPage.run(true)
+          } catch (error: unknown) {
+            PageErrorHandler.logError('Error in TweetPage.run', error)
+          }
+        })()
         return
       }
 
@@ -112,10 +136,10 @@ export const TweetPage = {
 
     Storage.setRetryCount(0)
 
-    await ScrollUtils.scrollPage()
+    await ScrollUtilities.scrollPage()
 
     if (CrawlerService.getCrawledTweetCount() === 0) {
-      location.href = URLS.BOOKMARK
+      location.assign(URLS.BOOKMARK)
       return
     }
 
@@ -126,8 +150,12 @@ export const TweetPage = {
       CrawlerService.resetCrawledTweetCount()
     }
 
-    TweetPage.run(true).catch((error: unknown) => {
-      PageErrorHandler.logError('Error in TweetPage.run', error)
-    })
+    ;(async () => {
+      try {
+        await TweetPage.run(true)
+      } catch (error: unknown) {
+        PageErrorHandler.logError('Error in TweetPage.run', error)
+      }
+    })()
   },
 }

--- a/src/services/crawler-service.ts
+++ b/src/services/crawler-service.ts
@@ -58,9 +58,13 @@ export class CrawlerService {
    */
   static startCrawling(): void {
     this.crawlTweetInterval ??= setInterval(() => {
-      this.crawlTweets().catch((error: unknown) => {
-        console.error('crawlTweets failed', error)
-      })
+      ;(async () => {
+        try {
+          await this.crawlTweets()
+        } catch (error: unknown) {
+          console.error('crawlTweets failed', error)
+        }
+      })()
     }, DELAYS.CRAWL_INTERVAL)
   }
 
@@ -68,10 +72,12 @@ export class CrawlerService {
    * 自動クローリングプロセスを停止し、インターバルタイマーをクリア。
    */
   static stopCrawling(): void {
-    if (this.crawlTweetInterval) {
-      clearInterval(this.crawlTweetInterval)
-      this.crawlTweetInterval = null
+    if (!this.crawlTweetInterval) {
+      return
     }
+
+    clearInterval(this.crawlTweetInterval)
+    this.crawlTweetInterval = null
   }
 
   /**

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -17,7 +17,7 @@ export const NotificationService = {
    *
    * @param {string} message - 送信するメッセージ内容
    * @param {(_response: Response) => void} [callback] - レスポンス受信時のコールバック関数
-   * @param {boolean} [withReply=false] - true の場合、メッセージにメンションを付加
+   * @param {boolean} [hasReply=false] - true の場合、メッセージにメンションを付加
    * @param {string} [customWebhookUrl] - カスタムWebhook URL。指定時はConfigManagerの設定より優先される
    * @returns {Promise<void>} 送信完了を表すPromise
    *
@@ -40,13 +40,13 @@ export const NotificationService = {
    * })
    * ```
    */
-  notifyDiscord(
+  async notifyDiscord(
     message: string,
     callback?: (_response: Response) => void,
-    withReply = false,
+    hasReply = false,
     customWebhookUrl?: string
   ): Promise<void> {
-    const mention = withReply ? `<@${DISCORD_MENTION_ID}>` : ''
+    const mention = hasReply ? `<@${DISCORD_MENTION_ID}>` : ''
     const comment = ConfigManager.getComment()
     const data = JSON.stringify({
       content: `${mention} ${message}\n${comment}`,
@@ -56,28 +56,27 @@ export const NotificationService = {
     const webhookUrl = customWebhookUrl || ConfigManager.getDiscordWebhookUrl()
     if (!webhookUrl) {
       console.warn('notifyDiscord: Discord Webhook URL is not set.')
-      return Promise.resolve()
+      return
     }
 
-    return fetch(webhookUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: data,
-    })
-      .then((response) => {
-        if (response.ok) {
-          console.log('notifyDiscord: success')
-        } else {
-          console.error('notifyDiscord: failed', response)
-        }
-        if (callback) {
-          callback(response)
-        }
+    try {
+      const response = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: data,
       })
-      .catch((error: unknown) => {
-        console.error('notifyDiscord: fetch error', error)
-      })
+      if (response.ok) {
+        console.log('notifyDiscord: success')
+      } else {
+        console.error('notifyDiscord: failed', response)
+      }
+      if (callback) {
+        callback(response)
+      }
+    } catch (error: unknown) {
+      console.error('notifyDiscord: fetch error', error)
+    }
   },
 }

--- a/src/services/queue-service.ts
+++ b/src/services/queue-service.ts
@@ -1,6 +1,6 @@
 import { Storage } from '@/core/storage'
 import { DELAYS } from '@/core/constants'
-import { AsyncUtils } from '@/utils/async'
+import { AsyncUtilities } from '@/utils/async'
 
 /**
  * ツイート処理キューと状態遷移を管理するサービス。
@@ -42,7 +42,7 @@ export const QueueService = {
     // Setを配列に変換して保存
     Storage.setWaitingTweets([...waitingTweetsSet])
 
-    await AsyncUtils.delay(DELAYS.CRAWL_INTERVAL)
+    await AsyncUtilities.delay(DELAYS.CRAWL_INTERVAL)
   },
 
   /**
@@ -77,7 +77,7 @@ export const QueueService = {
       Storage.setWaitingTweets([...waitingTweetsSet])
     }
 
-    await AsyncUtils.delay(DELAYS.CRAWL_INTERVAL)
+    await AsyncUtilities.delay(DELAYS.CRAWL_INTERVAL)
   },
 
   /**

--- a/src/services/tweet-service.ts
+++ b/src/services/tweet-service.ts
@@ -135,9 +135,10 @@ export const TweetService = {
     }
 
     // ツイートIDでソートして順序の一貫性を保証
-    const sortedTweets = [...savedTweetsMap.values()].toSorted((a, b) =>
-      a.tweetId.localeCompare(b.tweetId)
-    )
+    const sortedTweets = savedTweetsMap
+      .values()
+      .toArray()
+      .toSorted((a, b) => a.tweetId.localeCompare(b.tweetId))
     Storage.setSavedTweets(sortedTweets)
   },
 

--- a/src/types/userscript.d.ts
+++ b/src/types/userscript.d.ts
@@ -44,7 +44,7 @@ declare function GM_unregisterMenuCommand(menuCommandId: number): void
 
 // GM_config from Tampermonkey Config library (from @require)
 // eslint-disable-next-line camelcase
-declare const GM_config: (fields: GMConfigFields, init?: boolean) => void
+declare const GM_config: (fields: GMConfigFields, isInit?: boolean) => void
 
 // Event name fired by GM_config when configuration changes
 // eslint-disable-next-line camelcase

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,7 +1,7 @@
 /**
  * 非同期処理用のユーティリティ関数群
  */
-export const AsyncUtils = {
+export const AsyncUtilities = {
   /**
    * 指定した時間だけ処理を遅延する
    *
@@ -12,11 +12,11 @@ export const AsyncUtils = {
    * @example
    * ```typescript
    * // 1秒待機
-   * await AsyncUtils.delay(1000)
+   * await AsyncUtilities.delay(1000)
    *
    * // キャンセル可能な待機
    * const controller = new AbortController()
-   * await AsyncUtils.delay(5000, controller.signal)
+   * await AsyncUtilities.delay(5000, controller.signal)
    * ```
    */
   delay(ms: number, signal?: AbortSignal): Promise<void> {
@@ -48,7 +48,7 @@ export const AsyncUtils = {
    * @example
    * ```typescript
    * // 500ms〜1500msの間でランダム遅延
-   * await AsyncUtils.randomDelay(500, 1500)
+   * await AsyncUtilities.randomDelay(500, 1500)
    * ```
    */
   randomDelay(
@@ -57,7 +57,7 @@ export const AsyncUtils = {
     signal?: AbortSignal
   ): Promise<void> {
     const durationMs = Math.random() * (maxMs - minMs) + minMs
-    return AsyncUtils.delay(durationMs, signal)
+    return AsyncUtilities.delay(durationMs, signal)
   },
 
   /**
@@ -78,7 +78,7 @@ export const AsyncUtils = {
    *     break
    *   } catch (error) {
    *     if (attempt === maxRetries - 1) throw error
-   *     await AsyncUtils.exponentialBackoff(1000, attempt, 10000)
+   *     await AsyncUtilities.exponentialBackoff(1000, attempt, 10000)
    *   }
    * }
    * ```
@@ -90,7 +90,7 @@ export const AsyncUtils = {
     signal?: AbortSignal
   ): Promise<void> {
     const backoffMs = Math.min(baseMs * Math.pow(2, attempt), maxMs)
-    return AsyncUtils.delay(backoffMs, signal)
+    return AsyncUtilities.delay(backoffMs, signal)
   },
 
   /**
@@ -103,28 +103,31 @@ export const AsyncUtils = {
    *
    * @example
    * ```typescript
-   * const result = await AsyncUtils.withTimeout(
+   * const result = await AsyncUtilities.withTimeout(
    *   fetchData(),
    *   5000,
    *   'Data fetch timed out'
    * )
    * ```
    */
-  withTimeout<T>(
+  async withTimeout<T>(
     promise: Promise<T>,
     timeoutMs: number,
     timeoutMessage = 'Operation timed out'
   ): Promise<T> {
-    let timeoutId: NodeJS.Timeout
+    // Promise のexecutorは同期的に実行されるため必ず代入されるが、TS はそれを追跡できない
+    let timeoutId!: NodeJS.Timeout
     const timeoutPromise = new Promise<never>((_resolve, reject) => {
       timeoutId = setTimeout(() => {
         reject(new Error(timeoutMessage))
       }, timeoutMs)
     })
 
-    return Promise.race([promise, timeoutPromise]).finally(() => {
+    try {
+      return await Promise.race([promise, timeoutPromise])
+    } finally {
       clearTimeout(timeoutId)
-    })
+    }
   },
 
   /**
@@ -136,7 +139,7 @@ export const AsyncUtils = {
    *
    * @example
    * ```typescript
-   * const result = await AsyncUtils.retry(
+   * const result = await AsyncUtilities.retry(
    *   () => unstableApiCall(),
    *   { maxAttempts: 3, baseDelay: 1000 }
    * )
@@ -166,8 +169,13 @@ export const AsyncUtils = {
         }
 
         await (useExponentialBackoff
-          ? AsyncUtils.exponentialBackoff(baseDelay, attempt, 30_000, signal)
-          : AsyncUtils.delay(baseDelay, signal))
+          ? AsyncUtilities.exponentialBackoff(
+              baseDelay,
+              attempt,
+              30_000,
+              signal
+            )
+          : AsyncUtilities.delay(baseDelay, signal))
       }
     }
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -4,7 +4,7 @@ import { TIMEOUTS, URLS, SELECTORS } from '@/core/constants'
  * DOM操作とページ状態検出のためのユーティリティ関数群。
  * 要素の待機、ページエラー検出、返信読み込みボタンのクリック処理を提供。
  */
-export const DomUtils = {
+export const DomUtilities = {
   /**
    * 指定されたセレクターの要素がDOMに出現するまで待機。
    * @param selector - 待機する要素のCSSセレクター
@@ -75,7 +75,7 @@ export const DomUtils = {
     for (const tweetArticleElement of tweetArticleElements) {
       const text = tweetArticleElement.textContent
 
-      if (!text || !texts.some((t) => text.includes(t))) {
+      if (!text || texts.every((t) => !text.includes(t))) {
         continue
       }
 
@@ -103,7 +103,7 @@ export const DomUtils = {
       console.log(
         'checkAndNavigateToLogin: Login required detected, navigating to login page'
       )
-      location.href = URLS.LOGIN
+      location.assign(URLS.LOGIN)
       return true
     }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -31,14 +31,14 @@ export const ErrorHandler = {
         const element = document.querySelector(selector)
         if (element) {
           clearInterval(intervalId)
-          callback(element)
-            .then(() => {
+          ;(async () => {
+            try {
+              await callback(element)
               console.log(
                 `ErrorHandler: Successfully processed element: ${selector}`
               )
               resolve()
-            })
-            .catch((error: unknown) => {
+            } catch (error: unknown) {
               console.error(
                 `ErrorHandler: Callback failed for ${selector}:`,
                 error
@@ -48,7 +48,8 @@ export const ErrorHandler = {
               } else {
                 reject(new Error(String(error)))
               }
-            })
+            }
+          })()
         }
       }, 100)
     })
@@ -82,14 +83,14 @@ export const ErrorHandler = {
         const elements = document.querySelectorAll(selector)
         if (elements.length > 0) {
           clearInterval(intervalId)
-          callback(elements)
-            .then(() => {
+          ;(async () => {
+            try {
+              await callback(elements)
               console.log(
                 `ErrorHandler: Successfully processed ${elements.length} elements: ${selector}`
               )
               resolve()
-            })
-            .catch((error: unknown) => {
+            } catch (error: unknown) {
               console.error(
                 `ErrorHandler: Callback failed for ${selector}:`,
                 error
@@ -99,7 +100,8 @@ export const ErrorHandler = {
               } else {
                 reject(new Error(String(error)))
               }
-            })
+            }
+          })()
         }
       }, 100)
     })
@@ -132,14 +134,15 @@ export const ErrorHandler = {
           if (typeof callback === 'function') {
             const result = callback(dialog)
             if (result instanceof Promise) {
-              result
-                .then(() => {
-                  resolve()
-                })
-                .catch((error: unknown) => {
+              ;(async () => {
+                try {
+                  await result
+                } catch (error: unknown) {
                   console.error('ErrorHandler callback error:', error)
+                } finally {
                   resolve()
-                })
+                }
+              })()
             } else {
               resolve()
             }
@@ -191,14 +194,15 @@ export const ErrorHandler = {
           clearInterval(interval)
           const result = callback(tweetArticleElement)
           if (result instanceof Promise) {
-            result
-              .then(() => {
-                resolve()
-              })
-              .catch((error: unknown) => {
+            ;(async () => {
+              try {
+                await result
+              } catch (error: unknown) {
                 console.error('ErrorHandler callback error:', error)
+              } finally {
                 resolve()
-              })
+              }
+            })()
           } else {
             resolve()
           }

--- a/src/utils/page-error-handler.ts
+++ b/src/utils/page-error-handler.ts
@@ -1,6 +1,6 @@
 import { DELAYS } from '@/core/constants'
-import { DomUtils } from '@/utils/dom'
-import { AsyncUtils } from '@/utils/async'
+import { DomUtilities } from '@/utils/dom'
+import { AsyncUtilities } from '@/utils/async'
 
 /**
  * ページエラーハンドリングのオプション
@@ -27,14 +27,14 @@ export const PageErrorHandler = {
    * @param pageName - ログ用のページ名（例: 'Home', 'Search'）
    * @param methodNameOrError - メソッド名（文字列）またはエラーオブジェクト（自動検出時）
    * @param errorOrOptions - エラーオブジェクトまたはオプション
-   * @param optionsArg - エラーハンドリングオプション
+   * @param optionsArgument - エラーハンドリングオプション
    * @returns エラー処理完了を表すPromise
    *
    * @example
    * ```typescript
    * // 自動検出（推奨）
    * try {
-   *   await DomUtils.waitElement('.timeline')
+   *   await DomUtilities.waitElement('.timeline')
    * } catch (error) {
    *   await PageErrorHandler.handlePageError('Home', error)
    *   return
@@ -42,7 +42,7 @@ export const PageErrorHandler = {
    *
    * // メソッド名を手動指定
    * try {
-   *   await DomUtils.waitElement('.timeline')
+   *   await DomUtilities.waitElement('.timeline')
    * } catch (error) {
    *   await PageErrorHandler.handlePageError('Home', 'runHome', error)
    *   return
@@ -53,7 +53,7 @@ export const PageErrorHandler = {
     pageName: string,
     methodNameOrError: unknown,
     errorOrOptions?: any,
-    optionsArg?: PageErrorOptions
+    optionsArgument?: PageErrorOptions
   ): Promise<void> {
     // オーバーロードされたパラメータを処理する
     let methodName: string
@@ -64,7 +64,7 @@ export const PageErrorHandler = {
       // 旧シグネチャ: handlePageError(pageName, methodName, error, options)
       methodName = methodNameOrError
       error = errorOrOptions
-      options = optionsArg ?? {}
+      options = optionsArgument ?? {}
     } else {
       // 新シグネチャ: handlePageError(pageName, error, options)
       methodName = PageErrorHandler._getCallerName()
@@ -84,7 +84,7 @@ export const PageErrorHandler = {
     } = options
 
     // 失敗ページかどうかチェック
-    if (DomUtils.isFailedPage()) {
+    if (DomUtilities.isFailedPage()) {
       console.error(`${methodName}: failed page.`)
     }
 
@@ -97,7 +97,7 @@ export const PageErrorHandler = {
 
     // 必要に応じて待機してリロード
     if (shouldReload) {
-      await AsyncUtils.delay(waitTime)
+      await AsyncUtilities.delay(waitTime)
       location.reload()
     }
   },
@@ -105,12 +105,12 @@ export const PageErrorHandler = {
   /**
    * 標準的なエラーハンドリングで要素を待機する
    *
-   * DomUtils.waitElement を自動エラーハンドリングとリロードロジックでラップする。
+   * DomUtilities.waitElement を自動エラーハンドリングとリロードロジックでラップする。
    *
    * @param selector - 要素のCSSセレクター
    * @param pageName - ログ用のページ名
    * @param methodNameOrOptions - メソッド名（文字列）またはオプション（自動検出時）
-   * @param optionsArg - タイムアウトとエラーハンドリングを含む追加オプション
+   * @param optionsArgument - タイムアウトとエラーハンドリングを含む追加オプション
    * @returns 要素が見つかった場合に解決するPromise、エラー処理後にリジェクト
    *
    * @example
@@ -138,7 +138,7 @@ export const PageErrorHandler = {
           timeout?: number
           errorOptions?: PageErrorOptions
         },
-    optionsArg?: {
+    optionsArgument?: {
       timeout?: number
       errorOptions?: PageErrorOptions
     }
@@ -153,7 +153,7 @@ export const PageErrorHandler = {
     if (typeof methodNameOrOptions === 'string') {
       // 旧シグネチャ: waitForElementWithErrorHandling(selector, pageName, methodName, options)
       methodName = methodNameOrOptions
-      options = optionsArg ?? {}
+      options = optionsArgument ?? {}
     } else {
       // 新シグネチャ: waitForElementWithErrorHandling(selector, pageName, options)
       methodName = PageErrorHandler._getCallerName()
@@ -161,8 +161,8 @@ export const PageErrorHandler = {
     }
 
     try {
-      await DomUtils.waitElement(selector, options.timeout)
-      // DomUtils.waitElement は要素を返さないため、queryで取得する
+      await DomUtilities.waitElement(selector, options.timeout)
+      // DomUtilities.waitElement は要素を返さないため、queryで取得する
       const element = document.querySelector(selector)
       if (!element) {
         throw new Error(`Element ${selector} not found after waiting`)
@@ -188,7 +188,7 @@ export const PageErrorHandler = {
    * @param operation - 実行する非同期操作
    * @param pageName - ログ用のページ名
    * @param methodNameOrOptions - メソッド名（文字列）またはオプション（自動検出時）
-   * @param optionsArg - エラーハンドリングオプション
+   * @param optionsArgument - エラーハンドリングオプション
    * @returns 操作結果またはエラー処理後にundefinedを返すPromise
    *
    * @example
@@ -197,7 +197,7 @@ export const PageErrorHandler = {
    * await PageErrorHandler.executeWithErrorHandling(
    *   async () => {
    *     // 複雑なページ操作
-   *     const element = await DomUtils.waitElement('.timeline')
+   *     const element = await DomUtilities.waitElement('.timeline')
    *     await processElement(element)
    *   },
    *   'Home'
@@ -207,7 +207,7 @@ export const PageErrorHandler = {
    * await PageErrorHandler.executeWithErrorHandling(
    *   async () => {
    *     // 複雑なページ操作
-   *     const element = await DomUtils.waitElement('.timeline')
+   *     const element = await DomUtilities.waitElement('.timeline')
    *     await processElement(element)
    *   },
    *   'Home',
@@ -219,7 +219,7 @@ export const PageErrorHandler = {
     operation: () => Promise<T>,
     pageName: string,
     methodNameOrOptions?: string | PageErrorOptions,
-    optionsArg?: PageErrorOptions
+    optionsArgument?: PageErrorOptions
   ): Promise<T | undefined> {
     // オーバーロードされたパラメータを処理する
     let methodName: string
@@ -228,7 +228,7 @@ export const PageErrorHandler = {
     if (typeof methodNameOrOptions === 'string') {
       // 旧シグネチャ: executeWithErrorHandling(operation, pageName, methodName, options)
       methodName = methodNameOrOptions
-      options = optionsArg ?? {}
+      options = optionsArgument ?? {}
     } else {
       // 新シグネチャ: executeWithErrorHandling(operation, pageName, options)
       methodName = PageErrorHandler._getCallerName()
@@ -255,7 +255,7 @@ export const PageErrorHandler = {
    *
    * @param pageName - ページ名
    * @param methodNameOrAdditionalInfo - メソッド名（文字列）または追加情報（自動検出時）
-   * @param additionalInfoArg - オプションの追加情報
+   * @param additionalInfoArgument - オプションの追加情報
    *
    * @example
    * ```typescript
@@ -273,7 +273,7 @@ export const PageErrorHandler = {
   logPageStart(
     pageName: string,
     methodNameOrAdditionalInfo?: string | Record<string, any>,
-    additionalInfoArg?: Record<string, any>
+    additionalInfoArgument?: Record<string, any>
   ): void {
     // オーバーロードされたパラメータを処理する
     let methodName: string
@@ -282,7 +282,7 @@ export const PageErrorHandler = {
     if (typeof methodNameOrAdditionalInfo === 'string') {
       // 旧シグネチャ: logPageStart(pageName, methodName, additionalInfo)
       methodName = methodNameOrAdditionalInfo
-      additionalInfo = additionalInfoArg
+      additionalInfo = additionalInfoArgument
     } else {
       // 新シグネチャ: logPageStart(pageName, additionalInfo)
       methodName = PageErrorHandler._getCallerName()
@@ -366,8 +366,8 @@ export const PageErrorHandler = {
       const stackLines = stack.split('\n')
 
       // 呼び出し元を探す（Error()、このメソッド、logAction/logError をスキップ）
-      for (let i = 3; i < stackLines.length; i++) {
-        const line = stackLines[i]
+      for (let index = 3; index < stackLines.length; index++) {
+        const line = stackLines[index]
 
         // 各フォーマットの関数名にマッチ:
         // - "at functionName (...)"

--- a/src/utils/scroll.ts
+++ b/src/utils/scroll.ts
@@ -1,12 +1,12 @@
 import { DELAYS, THRESHOLDS } from '@/core/constants'
-import { DomUtils } from './dom'
-import { AsyncUtils } from './async'
+import { DomUtilities } from './dom'
+import { AsyncUtilities } from './async'
 
 /**
  * ページの自動スクロールと無限スクロール処理を管理するクラス。
  * コンテンツの動的読み込みと返信ボタンのクリックを自動化。
  */
-export class ScrollUtils {
+export class ScrollUtilities {
   private static scrollPageInterval: ReturnType<typeof setInterval> | null =
     null
 
@@ -39,8 +39,8 @@ export class ScrollUtils {
           behavior: 'smooth',
         })
 
-        DomUtils.clickMoreReplies()
-        DomUtils.clickMoreRepliesAggressive()
+        DomUtilities.clickMoreReplies()
+        DomUtilities.clickMoreRepliesAggressive()
 
         const newHeight = document.body.scrollHeight
 
@@ -74,7 +74,7 @@ export class ScrollUtils {
         top: window.innerHeight,
         behavior: 'smooth',
       })
-      await AsyncUtils.delay(DELAYS.CRAWL_INTERVAL)
+      await AsyncUtilities.delay(DELAYS.CRAWL_INTERVAL)
     }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,15 +105,17 @@ export default function webpackConfig(environment, argv) {
                 for (const [filename, source] of Object.entries(
                   compilation.assets
                 )) {
-                  if (filename.endsWith('.js')) {
-                    const content = source.source()
-                    const modifiedSource = banner + content
-
-                    compilation.updateAsset(
-                      filename,
-                      new compiler.webpack.sources.RawSource(modifiedSource)
-                    )
+                  if (!filename.endsWith('.js')) {
+                    continue
                   }
+
+                  const content = source.source()
+                  const modifiedSource = banner + content
+
+                  compilation.updateAsset(
+                    filename,
+                    new compiler.webpack.sources.RawSource(modifiedSource)
+                  )
                 }
               }
             )


### PR DESCRIPTION
## 概要

Renovate PR #495 (`@book000/eslint-config` 1.15.4 → 1.15.44) は、依存の
`eslint-plugin-unicorn` が v66 → v71.1.0 に上がることで、既存コードに対して
新たに以下のルールが違反として検出され CI が失敗していました。

- `unicorn/class-reference-in-static-methods`
- `unicorn/consistent-boolean-name`
- `unicorn/prefer-await`
- `unicorn/name-replacements`
- `unicorn/prefer-iterator-to-array`
- `unicorn/no-global-object-property-assignment`
- `unicorn/no-non-function-verb-prefix`
- `unicorn/prefer-object-define-properties`
- `unicorn/no-useless-template-literals`

本PRはこれらの指摘に対する機械的な修正のみを行い、挙動は変更していません。
`@book000/eslint-config` 自体のバージョンはこのPRでは変更していません
（Renovate PR側で更新される想定）。

## 主な変更内容

- `Storage` クラスの static メソッド内での `Storage.` 参照を `this.` に変更
- boolean を返す/受け取る変数・引数名を `is` プレフィックス付きに変更
  （例: `setLoginNotified(value)` → `setLoginNotified(isNotified)`）
- `.then()`/`.catch()` チェーンを `async`/`await` + `try`/`catch` に変換
  （fire-and-forget が必要な箇所は async IIFE でラップして挙動を維持）
- `AsyncUtils`/`DomUtils`/`ScrollUtils` を `AsyncUtilities`/`DomUtilities`/`ScrollUtilities` にリネーム
- テストファイルの `no-global-object-property-assignment` / `no-non-function-verb-prefix` は
  Jest のグローバルモック・スパイ変数の慣習的な命名を妨げるため、
  `eslint.config.mjs` のテスト/モック用オーバーライドで無効化
- `Object.defineProperty()` の複数呼び出しを `Object.defineProperties()` に統合
- `page-test-utils.ts` → `page-test-utilities.ts` にリネーム（`unicorn/name-replacements`）

## 検証

- `pnpm run lint`（prettier / eslint / tsc）: 全て pass
- `pnpm test`: 20 suites / 257 tests pass（既存の skip 15件はそのまま）