### PR TITLE
fix: reformat comment for prettier 3.9.4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",
     "jsdom": "29.1.1",
-    "prettier": "3.8.5",
+    "prettier": "3.9.4",
     "rimraf": "6.1.3",
     "run-z": "2.1.0",
     "ts-jest": "29.4.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1
       prettier:
-        specifier: 3.8.5
-        version: 3.8.5
+        specifier: 3.9.4
+        version: 3.9.4
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -607,9 +607,6 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/node@24.13.2':
-    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
@@ -2533,8 +2530,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.5:
-    resolution: {integrity: sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3651,7 +3648,7 @@ snapshots:
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.4.1':
@@ -3738,7 +3735,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -3865,10 +3862,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
-
-  '@types/node@24.13.2':
-    dependencies:
-      undici-types: 7.18.2
 
   '@types/node@24.13.3':
     dependencies:
@@ -5584,7 +5577,7 @@ snapshots:
   jest-haste-map@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5734,7 +5727,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -5768,7 +5761,7 @@ snapshots:
 
   jest-worker@30.4.1:
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       '@ungap/structured-clone': 1.3.2
       jest-util: 30.4.1
       merge-stream: 2.0.0
@@ -6160,7 +6153,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.5: {}
+  prettier@3.9.4: {}
 
   pretty-format@30.4.1:
     dependencies:

--- a/src/__tests__/pages/other-pages.test.ts
+++ b/src/__tests__/pages/other-pages.test.ts
@@ -152,7 +152,7 @@ describe('OtherPages', () => {
 
       let intervalCallback: (() => void) | undefined
 
-        // Mock setInterval to capture the callback
+      // Mock setInterval to capture the callback
       ;(globalThis.setInterval as jest.Mock).mockImplementation((callback) => {
         intervalCallback = callback
         return 123 // Mock interval ID


### PR DESCRIPTION
## What
Bumps `prettier` 3.8.5 -> 3.9.4 and reformats one comment in `src/__tests__/pages/other-pages.test.ts` to match the new version's formatting rules.

## Why
Renovate PR #516 bumps `prettier` to 3.9.4, but its CI (`Node CI / node-ci (.)`) fails: `lint:prettier` flags a pre-existing comment in `other-pages.test.ts` that prettier 3.8.5 and 3.9.4 format differently (indentation of a comment immediately preceding a semicolon-prefixed ASI-safety statement). Since the two prettier versions disagree on the correct format for this construct, the bump and the reformat must land together — reformatting alone (without the bump) would break `lint:prettier` under the currently-pinned 3.8.5.

## Verification
- `pnpm run lint` (prettier/eslint/tsc) passes locally.
- `pnpm test` passes locally (257 tests, 20 suites).
- No behavior change — cosmetic formatting only.

Once merged, #516 should pass CI (or Renovate will just no-op the version bump on rebase).
